### PR TITLE
Apply The Pitz Studio branding across the UI

### DIFF
--- a/docs/design/pitz-branding-improvements.md
+++ b/docs/design/pitz-branding-improvements.md
@@ -1,0 +1,113 @@
+# How to Maintain Pitz Branding but Improve the Look
+
+This guide captures a UI/UX review of the yamly app (at the time of the Pitz branding pass) and gives actionable directions to improve the look while keeping The Pitz Studio branding intact. Use it as the source of truth when refining the UI.
+
+---
+
+## 1. Branding constraints to preserve
+
+When making visual changes, keep these fixed:
+
+- **Palette**
+  - Page background: `#E8DCC4` (warm beige) — `--background` in [ui/app/globals.css](../../ui/app/globals.css)
+  - Primary text: `#1A1A1A` — `--foreground` / `--brand-text`
+  - Secondary text: `#6C6C6C` — `--brand-secondary`
+  - Accent (sparingly): `#9DC9B8` (sage) — `--brand-accent`
+  - Primary CTAs: `#000000` background, white text — `--brand-cta-bg` / `--brand-cta-text`
+  - Cards/surfaces: white `#FFFFFF` — `--brand-background`
+- **Typography:** Instrument Serif (headings), Work Sans (body). Loaded in [ui/app/layout.tsx](../../ui/app/layout.tsx). Keep JetBrains Mono for code.
+- **Credit footer:** The floating “The Pitz Studio” link in the bottom-right ([ui/components/BrandingBubble.tsx](../../ui/components/BrandingBubble.tsx)) is required; do not remove or move it. See the Pitz skill “Credit Footer” spec for styling.
+- **Shadows and cards:** Subtle shadow `0 4px 12px rgba(0,0,0,0.08)` is the standard card shadow; you may introduce a second, stronger shadow only for primary content (see improvement 3).
+
+Reference: [The Pitz Studio brand skill](file:///Users/noam/.cursor/skills/thepitz-branding/SKILL.md) and [ui/app/globals.css](../../ui/app/globals.css).
+
+---
+
+## 2. Current issues (expert review summary)
+
+These are the main issues identified with the current look so you know what to improve:
+
+1. **Full-page beige with no relief** — The whole page uses the same beige background. There’s no variation (e.g. a clear content band or alternate background), so the beige dominates and feels flat.
+2. **No elevation hierarchy** — Almost every surface uses the same shadow. Nothing reads as “closer” or “primary,” so the layout feels flat.
+3. **Weak typographic hierarchy** — The app title (“YAML Diff Viewer”) and section title (“What is yamly?”) are similar in size/weight. There’s no clear step-up (e.g. 2xl/3xl for the app name). Most body copy is small, so the page reads as one level.
+4. **Secondary controls look samey and low-contrast** — Test API, Help, and Export use similar gray/sage tints. Only “Run diff” reads as primary. Secondary actions don’t feel intentionally tiered.
+5. **Inconsistent use of sage and off-brand color** — Sage is used in many places without a clear rule. The “Input Requirements” accordion in the demo section still uses hardcoded blue (`text-blue-900`, `bg-blue-100`, etc.), which clashes with the Pitz palette.
+
+---
+
+## 3. Improvement directions with implementation notes
+
+Follow these directions one by one (or in small batches) to improve the look without breaking branding.
+
+### 3.1 Tame full-page beige with clear content bands
+
+- **What to do:** Keep `#E8DCC4` as the page background, but make most of the visible UI sit in a dominant “content” band (white or very light tint) so beige acts as a frame, not the main field.
+- **Where to change:** [ui/app/page.tsx](../../ui/app/page.tsx). Wrap the main content (e.g. from the tabs down, or from the demo section down) in a wrapper that uses `bg-[var(--brand-background)]` (or a very light tint). Keep the header and BrandingBubble placement and styling as-is.
+- **Concrete hint:** Add a main content wrapper with `bg-[var(--brand-background)]` and max-width; keep beige only on `body` or as outer margins/sides so the center reads as a clear content band.
+
+### 3.2 Increase header and section typography contrast
+
+- **What to do:** Give the app a clear top level (e.g. “YAML Diff Viewer” larger and in Instrument Serif). Make “What is yamly?” clearly secondary. Add one more step for body (e.g. intro at `text-base`, captions at `text-sm`).
+- **Where to change:** [ui/app/page.tsx](../../ui/app/page.tsx) for the app title; [ui/components/DemoSection.tsx](../../ui/components/DemoSection.tsx) for “What is yamly?” and section headings.
+- **Concrete hint:** Use `text-2xl` or `text-3xl` with Instrument Serif for “YAML Diff Viewer”; use `text-lg` or a different weight/color for “What is yamly?” so hierarchy is obvious.
+
+### 3.3 Vary card elevation instead of one shadow
+
+- **What to do:** Keep the current shadow for most cards. Introduce a stronger shadow only for 1–2 key surfaces (e.g. main editor container or the primary “Run diff” card) so primary content reads as elevated.
+- **Where to change:** [ui/app/globals.css](../../ui/app/globals.css) — add a second variable, e.g. `--shadow-primary: 0 8px 24px rgba(0,0,0,0.12)`. Apply it only to the main content card(s) in [ui/app/page.tsx](../../ui/app/page.tsx) and/or the editor/diff container.
+- **Concrete hint:** Leave header and small UI cards with the existing lighter shadow; use the new variable only for the main content area so elevation hierarchy is clear.
+
+### 3.4 Tier secondary buttons and links
+
+- **What to do:** Keep black for the single primary CTA (“Run diff”). Define two tiers: (1) “tool” actions (e.g. Test API, Export) with slightly stronger treatment; (2) “support” actions (e.g. Help, doc links) with a lighter treatment (e.g. text + hover only). Use the same palette; differentiate by contrast and weight.
+- **Where to change:** [ui/app/page.tsx](../../ui/app/page.tsx) for header buttons; any component that renders secondary actions.
+- **Concrete hint:** Tool actions: border or background at 25–30% opacity (sage or gray). Support actions: text color + hover underline or light background, no heavy border.
+
+### 3.5 Replace blue in Input Requirements with brand colors
+
+- **What to do:** Remove all blue from the “Input Requirements” accordion so it uses only Pitz tokens.
+- **Where to change:** [ui/components/DemoSection.tsx](../../ui/components/DemoSection.tsx). Find the expanded content for `expandedSection === "requirements"` and all nested blocks that use `text-blue-900`, `text-blue-800`, `bg-blue-100`, `text-blue-600`, etc.
+- **Concrete hint:** Replace with `--foreground` / `--brand-secondary` for text and `--brand-accent` (or `--brand-accent/10`–`/20`) for backgrounds and bullets. Keep structure and copy; only swap colors.
+
+### 3.6 Add subtle background variation in the main area
+
+- **What to do:** Within the main content band, add one level of separation using existing palette only (e.g. very light sage tint for the demo strip, or a light gray tint for the editor area).
+- **Where to change:** [ui/app/page.tsx](../../ui/app/page.tsx) and/or [ui/components/DemoSection.tsx](../../ui/components/DemoSection.tsx). Use CSS variables with low opacity (e.g. `bg-[var(--brand-accent)]/5`).
+- **Concrete hint:** Avoid new hex colors; use `--brand-accent` or `--brand-secondary` at 3–5% opacity so it still reads as Pitz.
+
+### 3.7 Tighten spacing rhythm and breathing room
+
+- **What to do:** Slightly increase vertical spacing between major sections (e.g. demo block vs editor) and give the editor grid a bit more vertical padding so the two columns don’t feel cramped.
+- **Where to change:** [ui/app/page.tsx](../../ui/app/page.tsx) — main content wrapper and spacing between sections; [ui/app/globals.css](../../ui/app/globals.css) if you add spacing utilities.
+- **Concrete hint:** Add `mb-10` or a spacer between the demo section and the main content; increase padding around the editor grid. Keep existing gaps inside components; only adjust between big blocks.
+
+### 3.8 Use sage deliberately for “active” and key emphasis
+
+- **What to do:** Define a simple rule: sage for “selected/active” and for one level of emphasis (e.g. selected tab, selected example card, primary focus ring). Use gray (`--brand-secondary`) for neutral borders and secondary text.
+- **Where to change:** [ui/app/page.tsx](../../ui/app/page.tsx) (tabs); [ui/components/DemoSection.tsx](../../ui/components/DemoSection.tsx) (example cards); [ui/components/ModeSelector.tsx](../../ui/components/ModeSelector.tsx); focus styles in [ui/app/globals.css](../../ui/app/globals.css).
+- **Concrete hint:** Apply sage consistently for active/selected states and one level of emphasis; use gray for everything else neutral so the accent feels intentional.
+
+---
+
+## 4. Implementation checklist
+
+Use this checklist when implementing the improvements (e.g. one item per PR or batch a few together):
+
+- [ ] **Content band** — Main content area on white/light band; beige as frame
+- [ ] **Header typography** — Larger Instrument Serif app title; clear section hierarchy
+- [ ] **Elevation variation** — Second shadow variable for primary content only
+- [ ] **Button tiers** — Tool vs support secondary actions; same palette, different weight/contrast
+- [ ] **Remove blue** — Replace all blue in DemoSection Input Requirements with brand tokens
+- [ ] **Background variation** — One subtle tint (accent or gray) in main area
+- [ ] **Spacing** — More vertical space between major sections and in editor area
+- [ ] **Sage-for-active** — Consistent rule: sage = active/emphasis; gray = neutral
+
+---
+
+## References
+
+- [The Pitz Studio brand guidelines](file:///Users/noam/.cursor/skills/thepitz-branding/SKILL.md) (skill)
+- [ui/app/globals.css](../../ui/app/globals.css) — CSS variables and base styles
+- [ui/app/layout.tsx](../../ui/app/layout.tsx) — Fonts and root layout
+- [ui/app/page.tsx](../../ui/app/page.tsx) — Main page structure and header
+- [ui/components/DemoSection.tsx](../../ui/components/DemoSection.tsx) — Demo strip and Input Requirements accordion

--- a/docs/design/pitz-branding-improvements.md
+++ b/docs/design/pitz-branding-improvements.md
@@ -19,7 +19,7 @@ When making visual changes, keep these fixed:
 - **Credit footer:** The floating “The Pitz Studio” link in the bottom-right ([ui/components/BrandingBubble.tsx](../../ui/components/BrandingBubble.tsx)) is required; do not remove or move it. See the Pitz skill “Credit Footer” spec for styling.
 - **Shadows and cards:** Subtle shadow `0 4px 12px rgba(0,0,0,0.08)` is the standard card shadow; you may introduce a second, stronger shadow only for primary content (see improvement 3).
 
-Reference: [The Pitz Studio brand skill](file:///Users/noam/.cursor/skills/thepitz-branding/SKILL.md) and [ui/app/globals.css](../../ui/app/globals.css).
+Reference: The Pitz Studio brand guidelines (local Cursor skill: thepitz-branding). See [ui/app/globals.css](../../ui/app/globals.css) for variables.
 
 ---
 
@@ -106,7 +106,7 @@ Use this checklist when implementing the improvements (e.g. one item per PR or b
 
 ## References
 
-- [The Pitz Studio brand guidelines](file:///Users/noam/.cursor/skills/thepitz-branding/SKILL.md) (skill)
+- The Pitz Studio brand guidelines (local Cursor skill: thepitz-branding); see [ui/app/globals.css](../../ui/app/globals.css) for variables
 - [ui/app/globals.css](../../ui/app/globals.css) — CSS variables and base styles
 - [ui/app/layout.tsx](../../ui/app/layout.tsx) — Fonts and root layout
 - [ui/app/page.tsx](../../ui/app/page.tsx) — Main page structure and header

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -1,15 +1,18 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #E8DCC4;
+  --foreground: #1A1A1A;
 
   /* Brand colors - The Pitz Studio */
-  --brand-primary: #2563EB;
-  --brand-text: #1E293B;
-  --brand-background: #ffffff;
+  --brand-accent: #9DC9B8;
+  --brand-cta-bg: #000000;
+  --brand-cta-text: #FFFFFF;
+  --brand-secondary: #6C6C6C;
+  --brand-text: #1A1A1A;
+  --brand-background: #FFFFFF;
 
-  /* Diff colors - GitHub-inspired */
+  /* Diff colors - GitHub-inspired (kept for semantics) */
   --diff-add-bg: #dafbe1;
   --diff-add-text: #1a7f37;
   --diff-remove-bg: #ffebe9;
@@ -19,8 +22,9 @@
   --diff-move-bg: #fbefff;
   --diff-move-text: #8250df;
 
-  /* Typography */
+  /* Typography - set by layout.tsx */
   --font-sans: var(--font-sans);
+  --font-serif: var(--font-serif);
   --font-mono: var(--font-mono);
 }
 
@@ -80,9 +84,9 @@ body {
   width: 20px;
 }
 
-/* Focus states using brand primary color */
+/* Focus states using brand accent */
 *:focus-visible {
-  outline: 2px solid var(--brand-primary);
+  outline: 2px solid var(--brand-accent);
   outline-offset: 2px;
 }
 
@@ -106,8 +110,9 @@ a[href^="https://about.thepitz.studio"]:hover {
 .prose h2,
 .prose h3,
 .prose h4 {
+  font-family: var(--font-serif), serif;
   color: var(--foreground);
-  font-weight: 600;
+  font-weight: 400;
   margin-top: 1.5em;
   margin-bottom: 0.5em;
 }
@@ -147,7 +152,7 @@ a[href^="https://about.thepitz.studio"]:hover {
 }
 
 .prose a {
-  color: var(--brand-primary);
+  color: var(--foreground);
   text-decoration: underline;
 }
 
@@ -166,10 +171,10 @@ a[href^="https://about.thepitz.studio"]:hover {
 }
 
 .prose blockquote {
-  border-left: 4px solid var(--brand-primary);
+  border-left: 4px solid var(--brand-accent);
   padding-left: 1em;
   margin: 1em 0;
-  color: #6b7280;
+  color: var(--brand-secondary);
   font-style: italic;
 }
 

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -47,9 +47,10 @@ body {
   font-family: var(--font-serif), serif;
 }
 
-/* CodeMirror overrides */
+/* CodeMirror overrides - white editor surface per Pitz branding */
 .cm-editor {
   height: 100%;
+  background: var(--brand-background);
 }
 
 .cm-scroller {

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -22,6 +22,13 @@
   --diff-move-bg: #fbefff;
   --diff-move-text: #8250df;
 
+  /* Prose/theme-aligned UI (replaces hardcoded hex in prose) */
+  --prose-border: color-mix(in srgb, var(--brand-secondary) 22%, transparent);
+  --code-bg: color-mix(in srgb, var(--brand-secondary) 12%, var(--brand-background));
+  --prose-th-bg: color-mix(in srgb, var(--brand-secondary) 8%, var(--brand-background));
+  --pre-bg: #1f2937;
+  --pre-fg: #f9fafb;
+
   /* Typography - set by layout.tsx */
   --font-sans: var(--font-sans);
   --font-serif: var(--font-serif);
@@ -34,6 +41,10 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: var(--font-sans), system-ui, sans-serif;
+}
+
+.font-serif {
+  font-family: var(--font-serif), serif;
 }
 
 /* CodeMirror overrides */
@@ -119,18 +130,18 @@ a[href^="https://about.thepitz.studio"]:hover {
 
 .prose h1 {
   font-size: 2em;
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid var(--prose-border);
   padding-bottom: 0.3em;
 }
 
 .prose h2 {
   font-size: 1.5em;
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid var(--prose-border);
   padding-bottom: 0.3em;
 }
 
 .prose code {
-  background-color: #f3f4f6;
+  background-color: var(--code-bg);
   padding: 0.2em 0.4em;
   border-radius: 0.25rem;
   font-size: 0.875em;
@@ -138,8 +149,8 @@ a[href^="https://about.thepitz.studio"]:hover {
 }
 
 .prose pre {
-  background-color: #1f2937;
-  color: #f9fafb;
+  background-color: var(--pre-bg);
+  color: var(--pre-fg);
   padding: 1em;
   border-radius: 0.5rem;
   overflow-x: auto;
@@ -186,13 +197,13 @@ a[href^="https://about.thepitz.studio"]:hover {
 
 .prose th,
 .prose td {
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--prose-border);
   padding: 0.5em 1em;
   text-align: left;
 }
 
 .prose th {
-  background-color: #f9fafb;
+  background-color: var(--prose-th-bg);
   font-weight: 600;
 }
 

--- a/ui/app/layout.tsx
+++ b/ui/app/layout.tsx
@@ -1,10 +1,16 @@
 import type { Metadata } from "next";
-import { Inter, JetBrains_Mono } from "next/font/google";
+import { Instrument_Serif, Work_Sans, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import Providers from "./providers";
 import BrandingBubble from "@/components/BrandingBubble";
 
-const inter = Inter({
+const instrumentSerif = Instrument_Serif({
+  weight: "400",
+  variable: "--font-serif",
+  subsets: ["latin"],
+});
+
+const workSans = Work_Sans({
   variable: "--font-sans",
   subsets: ["latin"],
 });
@@ -31,7 +37,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${inter.variable} ${jetbrainsMono.variable} antialiased`}
+        className={`${instrumentSerif.variable} ${workSans.variable} ${jetbrainsMono.variable} antialiased`}
       >
         <Providers>{children}</Providers>
         <BrandingBubble />

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -156,12 +156,12 @@ export default function Home() {
       <header className="border-b border-[var(--brand-secondary)]/30 bg-[var(--brand-background)] sticky top-0 z-10 shadow-[0_4px_12px_rgba(0,0,0,0.08)]">
         <div className="max-w-[1200px] mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between h-auto sm:h-16 py-3 sm:py-0 gap-3 sm:gap-0">
-            <div className="flex items-center gap-4">
+            <div className="flex min-w-0 flex-1 sm:flex-initial items-center gap-2 sm:gap-4">
               <a
                 href="https://about.thepitz.studio/"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex items-center gap-2 text-[var(--brand-text)] text-sm sm:text-base font-normal hover:opacity-80 transition-opacity"
+                className="flex flex-shrink-0 items-center gap-2 text-[var(--brand-text)] text-sm sm:text-base font-normal hover:opacity-80 transition-opacity"
                 aria-label="The Pitz Studio"
               >
                 <Image
@@ -174,15 +174,15 @@ export default function Home() {
                 <span>the pitz studio</span>
               </a>
               <span className="text-[var(--brand-secondary)]/50 hidden sm:inline">|</span>
-              <h1 className="text-xl font-serif font-normal text-[var(--foreground)]">
+              <h1 className="text-lg sm:text-xl font-serif font-normal text-[var(--foreground)] truncate min-w-0">
                 YAML Diff Viewer
               </h1>
             </div>
-            <div className="flex items-center gap-2 sm:gap-3 w-full sm:w-auto">
+            <div className="flex flex-wrap items-center gap-2 sm:flex-nowrap sm:gap-3 w-full sm:w-auto">
               <Tooltip content="Check if the API server is reachable and responding">
                 <button
                   onClick={handleTestApi}
-                  className="px-3 sm:px-4 py-2 bg-[var(--brand-secondary)]/20 text-[var(--foreground)] rounded-lg hover:bg-[var(--brand-secondary)]/30 transition-colors text-sm sm:text-base border border-[var(--brand-secondary)]/30"
+                  className="px-3 sm:px-4 py-2.5 sm:py-2 bg-[var(--brand-secondary)]/20 text-[var(--foreground)] rounded-lg hover:bg-[var(--brand-secondary)]/30 transition-colors text-sm sm:text-base border border-[var(--brand-secondary)]/30 touch-manipulation"
                   aria-label="Test API connection"
                 >
                   Test API
@@ -197,7 +197,7 @@ export default function Home() {
                 <button
                   onClick={handleRunDiff}
                   disabled={diffMutation.isPending || !oldYaml.trim() || !newYaml.trim()}
-                  className={`px-4 py-2 rounded-lg hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-all text-sm font-medium flex-1 sm:flex-initial uppercase ${
+                  className={`w-full sm:w-auto px-4 py-2.5 sm:py-2 rounded-lg hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-all text-sm font-medium flex-1 sm:flex-initial uppercase touch-manipulation ${
                     diffMutation.isPending || !oldYaml.trim() || !newYaml.trim()
                       ? "bg-[var(--brand-secondary)]/40 text-[var(--brand-cta-text)]"
                       : "bg-[var(--brand-cta-bg)] text-[var(--brand-cta-text)]"
@@ -237,7 +237,7 @@ export default function Home() {
               <Tooltip content="Open help and documentation">
                 <button
                   onClick={() => setShowHelp(true)}
-                  className="px-3 sm:px-4 py-2 bg-[var(--brand-secondary)]/15 text-[var(--foreground)] rounded-lg hover:bg-[var(--brand-secondary)]/25 transition-colors text-sm sm:text-base border border-[var(--brand-secondary)]/20"
+                  className="px-3 sm:px-4 py-2.5 sm:py-2 bg-[var(--brand-secondary)]/15 text-[var(--foreground)] rounded-lg hover:bg-[var(--brand-secondary)]/25 transition-colors text-sm sm:text-base border border-[var(--brand-secondary)]/20 touch-manipulation"
                   aria-label="Open help"
                 >
                   Help

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -174,7 +174,7 @@ export default function Home() {
                 <span>the pitz studio</span>
               </a>
               <span className="text-[var(--brand-secondary)]/50 hidden sm:inline">|</span>
-              <h1 className="text-xl font-serif font-normal text-[var(--foreground)]" style={{ fontFamily: "var(--font-serif), serif" }}>
+              <h1 className="text-xl font-serif font-normal text-[var(--foreground)]">
                 YAML Diff Viewer
               </h1>
             </div>

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -151,17 +151,17 @@ export default function Home() {
   };
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-[var(--background)]">
       {/* Header */}
-      <header className="border-b border-gray-200 bg-white sticky top-0 z-10">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <header className="border-b border-[var(--brand-secondary)]/30 bg-[var(--brand-background)] sticky top-0 z-10 shadow-[0_4px_12px_rgba(0,0,0,0.08)]">
+        <div className="max-w-[1200px] mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between h-auto sm:h-16 py-3 sm:py-0 gap-3 sm:gap-0">
             <div className="flex items-center gap-4">
               <a
                 href="https://about.thepitz.studio/"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex items-center gap-2 text-[var(--brand-text)] font-sans text-sm sm:text-base font-normal hover:opacity-80 transition-opacity"
+                className="flex items-center gap-2 text-[var(--brand-text)] text-sm sm:text-base font-normal hover:opacity-80 transition-opacity"
                 aria-label="The Pitz Studio"
               >
                 <Image
@@ -173,8 +173,8 @@ export default function Home() {
                 />
                 <span>the pitz studio</span>
               </a>
-              <span className="text-gray-300 hidden sm:inline">|</span>
-              <h1 className="text-xl font-semibold text-gray-900">
+              <span className="text-[var(--brand-secondary)]/50 hidden sm:inline">|</span>
+              <h1 className="text-xl font-serif font-normal text-[var(--foreground)]" style={{ fontFamily: "var(--font-serif), serif" }}>
                 YAML Diff Viewer
               </h1>
             </div>
@@ -182,7 +182,7 @@ export default function Home() {
               <Tooltip content="Check if the API server is reachable and responding">
                 <button
                   onClick={handleTestApi}
-                  className="px-3 sm:px-4 py-2 bg-gray-500 text-white rounded-lg hover:bg-gray-600 transition-colors text-sm sm:text-base"
+                  className="px-3 sm:px-4 py-2 bg-[var(--brand-secondary)]/20 text-[var(--foreground)] rounded-lg hover:bg-[var(--brand-secondary)]/30 transition-colors text-sm sm:text-base border border-[var(--brand-secondary)]/30"
                   aria-label="Test API connection"
                 >
                   Test API
@@ -197,11 +197,11 @@ export default function Home() {
                 <button
                   onClick={handleRunDiff}
                   disabled={diffMutation.isPending || !oldYaml.trim() || !newYaml.trim()}
-                  className={`px-3 sm:px-4 py-2 rounded-lg hover:opacity-90 disabled:bg-gray-300 disabled:cursor-not-allowed transition-all text-sm sm:text-base flex-1 sm:flex-initial ${
+                  className={`px-4 py-2 rounded-lg hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-all text-sm font-medium flex-1 sm:flex-initial uppercase ${
                     diffMutation.isPending || !oldYaml.trim() || !newYaml.trim()
-                      ? 'bg-gray-300'
-                      : 'bg-[var(--brand-primary)]'
-                  } text-white`}
+                      ? "bg-[var(--brand-secondary)]/40 text-[var(--brand-cta-text)]"
+                      : "bg-[var(--brand-cta-bg)] text-[var(--brand-cta-text)]"
+                  }`}
                   aria-label="Run diff to compare documents"
                 >
                   {diffMutation.isPending ? (
@@ -230,14 +230,14 @@ export default function Home() {
                       <span className="sm:hidden">...</span>
                     </span>
                   ) : (
-                    "Run Diff"
+                    "Run diff →"
                   )}
                 </button>
               </Tooltip>
               <Tooltip content="Open help and documentation">
                 <button
                   onClick={() => setShowHelp(true)}
-                  className="px-3 sm:px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors text-sm sm:text-base"
+                  className="px-3 sm:px-4 py-2 bg-[var(--brand-secondary)]/15 text-[var(--foreground)] rounded-lg hover:bg-[var(--brand-secondary)]/25 transition-colors text-sm sm:text-base border border-[var(--brand-secondary)]/20"
                   aria-label="Open help"
                 >
                   Help
@@ -256,15 +256,15 @@ export default function Home() {
       </header>
 
       {/* Tabs */}
-      <div className="border-b border-gray-200 bg-white">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="border-b border-[var(--brand-secondary)]/30 bg-[var(--brand-background)]">
+        <div className="max-w-[1200px] mx-auto px-4 sm:px-6 lg:px-8">
           <nav className="flex space-x-8">
             <button
               onClick={() => setViewMode("editor")}
               className={`py-4 px-1 border-b-2 font-medium text-sm ${
                 viewMode === "editor"
-                  ? "text-[var(--brand-primary)] border-[var(--brand-primary)]"
-                  : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+                  ? "text-[var(--foreground)] border-[var(--brand-cta-bg)]"
+                  : "border-transparent text-[var(--brand-secondary)] hover:text-[var(--foreground)] hover:border-[var(--brand-secondary)]/40"
               }`}
             >
               Editor
@@ -275,8 +275,8 @@ export default function Home() {
                 disabled={!diff}
                 className={`py-4 px-1 border-b-2 font-medium text-sm ${
                   viewMode === "diff"
-                    ? "text-[var(--brand-primary)] border-[var(--brand-primary)]"
-                    : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300 disabled:opacity-50 disabled:cursor-not-allowed"
+                    ? "text-[var(--foreground)] border-[var(--brand-cta-bg)]"
+                    : "border-transparent text-[var(--brand-secondary)] hover:text-[var(--foreground)] hover:border-[var(--brand-secondary)]/40 disabled:opacity-50 disabled:cursor-not-allowed"
                 }`}
                 aria-label="View diff results"
               >
@@ -300,38 +300,30 @@ export default function Home() {
       />
 
       {/* Main Content */}
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+      <main className="max-w-[1200px] mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12">
         {apiTestResult && (
-          <div className={`mb-4 border rounded-lg p-4 ${
+          <div className={`mb-4 border rounded-lg p-4 bg-[var(--brand-background)] shadow-[0_4px_12px_rgba(0,0,0,0.08)] ${
             apiTestResult.includes("reachable") || apiTestResult.includes("OK")
-              ? "bg-green-50 border-green-200"
-              : "bg-yellow-50 border-yellow-200"
+              ? "border-green-300"
+              : "border-amber-300"
           }`}>
             <div className="flex items-start">
               <div className="flex-shrink-0">
                 {apiTestResult.includes("reachable") || apiTestResult.includes("OK") ? (
-                  <svg className="h-5 w-5 text-green-400" viewBox="0 0 20 20" fill="currentColor">
+                  <svg className="h-5 w-5 text-green-600" viewBox="0 0 20 20" fill="currentColor">
                     <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
                   </svg>
                 ) : (
-                  <svg className="h-5 w-5 text-yellow-400" viewBox="0 0 20 20" fill="currentColor">
+                  <svg className="h-5 w-5 text-amber-600" viewBox="0 0 20 20" fill="currentColor">
                     <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
                   </svg>
                 )}
               </div>
               <div className="ml-3">
-                <h3 className={`text-sm font-medium ${
-                  apiTestResult.includes("reachable") || apiTestResult.includes("OK")
-                    ? "text-green-800"
-                    : "text-yellow-800"
-                }`}>
+                <h3 className="text-sm font-medium text-[var(--foreground)]">
                   API Connection Test
                 </h3>
-                <div className={`mt-2 text-sm ${
-                  apiTestResult.includes("reachable") || apiTestResult.includes("OK")
-                    ? "text-green-700"
-                    : "text-yellow-700"
-                }`}>
+                <div className="mt-2 text-sm text-[var(--brand-secondary)]">
                   <p>{apiTestResult}</p>
                 </div>
               </div>
@@ -339,11 +331,11 @@ export default function Home() {
           </div>
         )}
         {error && (
-          <div className="mb-4 bg-red-50 border border-red-200 rounded-lg p-4">
+          <div className="mb-4 bg-[var(--brand-background)] border border-red-300 rounded-lg p-4 shadow-[0_4px_12px_rgba(0,0,0,0.08)]">
             <div className="flex">
               <div className="flex-shrink-0">
                 <svg
-                  className="h-5 w-5 text-red-400"
+                  className="h-5 w-5 text-red-500"
                   viewBox="0 0 20 20"
                   fill="currentColor"
                 >
@@ -355,18 +347,18 @@ export default function Home() {
                 </svg>
               </div>
               <div className="ml-3 flex-1">
-                <h3 className="text-sm font-medium text-red-800">Error</h3>
-                <div className="mt-2 text-sm text-red-700">
-                  <pre className="whitespace-pre-wrap font-sans">{error}</pre>
+                <h3 className="text-sm font-medium text-[var(--foreground)]">Error</h3>
+                <div className="mt-2 text-sm text-[var(--brand-secondary)]">
+                  <pre className="whitespace-pre-wrap">{error}</pre>
                 </div>
                 {error.includes("document:") && (
-                  <div className="mt-3 p-3 bg-red-100 rounded border border-red-300">
-                    <p className="text-xs text-red-800 font-medium mb-1">
+                  <div className="mt-3 p-3 bg-red-50 rounded border border-red-200">
+                    <p className="text-xs text-[var(--foreground)] font-medium mb-1">
                       How to fix:
                     </p>
-                    <ul className="text-xs text-red-700 list-disc list-inside space-y-1">
-                      <li>Ensure your YAML has <code className="bg-red-200 px-1 rounded">document:</code> as the top-level key</li>
-                      <li>All sections must have a <code className="bg-red-200 px-1 rounded">marker</code> field</li>
+                    <ul className="text-xs text-[var(--brand-secondary)] list-disc list-inside space-y-1">
+                      <li>Ensure your YAML has <code className="bg-red-100 px-1 rounded">document:</code> as the top-level key</li>
+                      <li>All sections must have a <code className="bg-red-100 px-1 rounded">marker</code> field</li>
                       <li>Check that your YAML syntax is valid</li>
                       <li>Try using one of the demo examples above as a reference</li>
                     </ul>
@@ -380,10 +372,10 @@ export default function Home() {
         {viewMode === "editor" ? (
           <div className="space-y-6">
             {!oldYaml && !newYaml && (
-              <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+              <div className="bg-[var(--brand-background)] border border-[var(--brand-accent)]/50 rounded-lg p-4 shadow-[0_4px_12px_rgba(0,0,0,0.08)]">
                 <div className="flex items-start gap-3">
                   <svg
-                    className="h-5 w-5 text-blue-600 mt-0.5 flex-shrink-0"
+                    className="h-5 w-5 text-[var(--brand-accent)] mt-0.5 flex-shrink-0"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"
@@ -396,11 +388,11 @@ export default function Home() {
                     />
                   </svg>
                   <div className="flex-1">
-                    <p className="text-sm text-blue-800">
+                    <p className="text-sm text-[var(--foreground)]">
                       <strong>Get started:</strong> Upload or paste two YAML
                       documents, or try an example from the demo section above.
                       {diffMode === "legal_document" && (
-                        <> Make sure your documents have <code className="bg-blue-100 px-1 rounded">document:</code> as the top-level key.</>
+                        <> Make sure your documents have <code className="bg-[var(--brand-accent)]/20 px-1 rounded">document:</code> as the top-level key.</>
                       )}
                     </p>
                   </div>
@@ -450,7 +442,7 @@ export default function Home() {
               <DiffView diff={diff} oldYaml={oldYaml} newYaml={newYaml} />
             ) : (
               <div className="text-center py-12">
-                <p className="text-gray-500">
+                <p className="text-[var(--brand-secondary)]">
                   Run a diff to see changes here.
                 </p>
               </div>

--- a/ui/components/BrandingBubble.tsx
+++ b/ui/components/BrandingBubble.tsx
@@ -9,7 +9,7 @@ export default function BrandingBubble() {
       target="_blank"
       rel="noopener noreferrer"
       aria-label="Made by The Pitz Studio"
-      className="fixed bottom-4 right-4 z-50 bg-white text-[var(--brand-text)] border border-gray-200 px-4 py-2 rounded-lg shadow-lg hover:shadow-xl transition-all duration-200 hover:scale-105 focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)] focus:ring-offset-2 hidden md:flex items-center gap-2"
+      className="fixed bottom-4 right-4 z-50 bg-[var(--brand-background)] text-[var(--brand-text)] border border-[var(--brand-secondary)]/30 px-4 py-2 rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.08)] hover:shadow-xl transition-all duration-200 hover:scale-105 focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:ring-offset-2 hidden md:flex items-center gap-2"
     >
       <Image
         src="/favicon.svg"

--- a/ui/components/BrandingBubble.tsx
+++ b/ui/components/BrandingBubble.tsx
@@ -14,7 +14,6 @@ export default function BrandingBubble() {
       rel="noopener noreferrer"
       aria-label="Made by The Pitz Studio"
       className="fixed bottom-4 right-4 z-50 bg-white/90 backdrop-blur-sm text-[var(--brand-text)] border border-[var(--brand-secondary)]/20 px-3 py-2 rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.08)] hover:shadow-md hover:underline font-semibold text-sm transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:ring-offset-2 hidden md:inline-flex items-center gap-2"
-      style={{ color: "var(--brand-text)" }}
     >
       <Image
         src="/favicon.svg"

--- a/ui/components/BrandingBubble.tsx
+++ b/ui/components/BrandingBubble.tsx
@@ -2,6 +2,10 @@
 
 import Image from "next/image";
 
+/**
+ * Floating credit footer per The Pitz Studio brand guidelines (required on every page).
+ * Fixed bottom-right, semi-opaque with backdrop blur, logo + "The Pitz Studio" link.
+ */
 export default function BrandingBubble() {
   return (
     <a
@@ -9,7 +13,8 @@ export default function BrandingBubble() {
       target="_blank"
       rel="noopener noreferrer"
       aria-label="Made by The Pitz Studio"
-      className="fixed bottom-4 right-4 z-50 bg-[var(--brand-background)] text-[var(--brand-text)] border border-[var(--brand-secondary)]/30 px-4 py-2 rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.08)] hover:shadow-xl transition-all duration-200 hover:scale-105 focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:ring-offset-2 hidden md:flex items-center gap-2"
+      className="fixed bottom-4 right-4 z-50 bg-white/90 backdrop-blur-sm text-[var(--brand-text)] border border-[var(--brand-secondary)]/20 px-3 py-2 rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.08)] hover:shadow-md hover:underline font-semibold text-sm transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:ring-offset-2 hidden md:inline-flex items-center gap-2"
+      style={{ color: "var(--brand-text)" }}
     >
       <Image
         src="/favicon.svg"
@@ -18,7 +23,7 @@ export default function BrandingBubble() {
         height={24}
         className="flex-shrink-0"
       />
-      <span className="text-sm font-medium">The Pitz Studio</span>
+      <span>The Pitz Studio</span>
     </a>
   );
 }

--- a/ui/components/ChangeCard.tsx
+++ b/ui/components/ChangeCard.tsx
@@ -42,7 +42,7 @@ function getChangeTypeStyles(changeType: ChangeType) {
       };
     default:
       return {
-        badge: "bg-gray-100 text-gray-800 border-gray-300",
+        badge: "bg-gray-100 text-[var(--foreground)] border-[var(--brand-secondary)]/40",
         bg: "bg-gray-50",
       };
   }
@@ -136,7 +136,7 @@ function DiffContent({ oldContent, newContent }: DiffContentProps) {
     return (
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div className="bg-red-50 border border-red-200 rounded p-3">
-          <div className="text-sm text-gray-500 italic font-mono">(empty)</div>
+          <div className="text-sm text-[var(--brand-secondary)] italic font-mono">(empty)</div>
         </div>
         <div className="bg-green-50 border border-green-200 rounded p-3 overflow-x-auto">
           <pre className="whitespace-pre-wrap text-sm font-mono">
@@ -157,7 +157,7 @@ function DiffContent({ oldContent, newContent }: DiffContentProps) {
           </pre>
         </div>
         <div className="bg-green-50 border border-green-200 rounded p-3">
-          <div className="text-sm text-gray-500 italic font-mono">(empty)</div>
+          <div className="text-sm text-[var(--brand-secondary)] italic font-mono">(empty)</div>
         </div>
       </div>
     );
@@ -326,25 +326,25 @@ export default function ChangeCard({ change, index, oldYaml, newYaml }: ChangeCa
       oldSectionYaml === newSectionYaml);
 
   return (
-    <div className={`border rounded-lg ${styles.bg} ${isExpanded ? "" : "overflow-hidden"}`} data-testid="change-card">
+    <div className={`border border-[var(--brand-secondary)]/20 rounded-lg bg-[var(--brand-background)] shadow-[0_4px_12px_rgba(0,0,0,0.08)] ${isExpanded ? "" : "overflow-hidden"}`} data-testid="change-card">
       <div
         className="px-3 sm:px-4 py-3 cursor-pointer hover:bg-opacity-80 transition-colors"
         onClick={() => setIsExpanded(!isExpanded)}
       >
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
           <div className="flex flex-wrap items-center gap-2 sm:gap-3">
-            <span className="text-sm font-medium text-gray-500">#{index + 1}</span>
+            <span className="text-sm font-medium text-[var(--brand-secondary)]">#{index + 1}</span>
             <span
               className={`px-2 py-1 text-xs font-semibold rounded border ${styles.badge}`}
             >
               {formatChangeType(change.change_type)}
             </span>
-            <span className="text-sm font-mono text-gray-700">
+            <span className="text-sm font-mono text-[var(--foreground)]">
               Marker: {change.marker}
             </span>
             {hasPathChange && change.change_type === ChangeType.SECTION_MOVED && (
               <div
-                className="flex items-center gap-2 text-xs text-gray-700 bg-purple-50 px-2 py-1 rounded border border-purple-200"
+                className="flex items-center gap-2 text-xs text-[var(--foreground)] bg-purple-50 px-2 py-1 rounded border border-purple-200"
                 data-testid="movement-indicator"
                 role="status"
                 aria-label={`Section moved from ${formatMarkerPath(change.old_marker_path)} to ${formatMarkerPath(change.new_marker_path)}`}
@@ -382,13 +382,13 @@ export default function ChangeCard({ change, index, oldYaml, newYaml }: ChangeCa
           </div>
           <div className="flex items-center gap-2">
             {discussion && discussion.comments.length > 0 && (
-              <span className="text-xs text-gray-500">
+              <span className="text-xs text-[var(--brand-secondary)]">
                 {discussion.comments.length} comment
                 {discussion.comments.length !== 1 ? "s" : ""}
               </span>
             )}
             <svg
-              className={`w-5 h-5 text-gray-400 transition-transform ${
+              className={`w-5 h-5 text-[var(--brand-secondary)] transition-transform ${
                 isExpanded ? "rotate-180" : ""
               }`}
               fill="none"
@@ -410,21 +410,21 @@ export default function ChangeCard({ change, index, oldYaml, newYaml }: ChangeCa
         <div className="px-4 pb-4 space-y-4">
           {isMetadataChange && (
             <div>
-              <h4 className="text-sm font-semibold text-gray-700 mb-2">
+              <h4 className="text-sm font-semibold text-[var(--foreground)] mb-2">
                 Metadata Change: {metadataFieldPath}
               </h4>
               <div className="grid grid-cols-2 gap-4">
                 <div className="bg-red-50 border border-red-200 rounded p-3">
-                  <div className="text-xs font-semibold text-gray-600 mb-1">Old Value:</div>
-                  <div className="text-sm font-mono text-gray-800">
+                  <div className="text-xs font-semibold text-[var(--brand-secondary)] mb-1">Old Value:</div>
+                  <div className="text-sm font-mono text-[var(--foreground)]">
                     {change.old_content !== null && change.old_content !== undefined
                       ? String(change.old_content)
                       : "(empty)"}
                   </div>
                 </div>
                 <div className="bg-green-50 border border-green-200 rounded p-3">
-                  <div className="text-xs font-semibold text-gray-600 mb-1">New Value:</div>
-                  <div className="text-sm font-mono text-gray-800">
+                  <div className="text-xs font-semibold text-[var(--brand-secondary)] mb-1">New Value:</div>
+                  <div className="text-sm font-mono text-[var(--foreground)]">
                     {change.new_content !== null && change.new_content !== undefined
                       ? String(change.new_content)
                       : "(empty)"}
@@ -436,7 +436,7 @@ export default function ChangeCard({ change, index, oldYaml, newYaml }: ChangeCa
 
           {hasTitleChange && (
             <div>
-              <h4 className="text-sm font-semibold text-gray-700 mb-2">Title Change:</h4>
+              <h4 className="text-sm font-semibold text-[var(--foreground)] mb-2">Title Change:</h4>
               <div className="grid grid-cols-2 gap-4">
                 <div className="bg-red-50 border border-red-200 rounded p-3">
                   <div className="text-sm font-mono">
@@ -454,7 +454,7 @@ export default function ChangeCard({ change, index, oldYaml, newYaml }: ChangeCa
 
           {hasContentChange && (
             <div>
-              <h4 className="text-sm font-semibold text-gray-700 mb-2">Content Change:</h4>
+              <h4 className="text-sm font-semibold text-[var(--foreground)] mb-2">Content Change:</h4>
               <div className="overflow-x-auto">
                 <DiffContent
                   oldContent={change.old_content}
@@ -471,7 +471,7 @@ export default function ChangeCard({ change, index, oldYaml, newYaml }: ChangeCa
                 e.stopPropagation();
                 setShowFullSection(!showFullSection);
               }}
-              className="flex items-center gap-2 text-sm font-semibold text-gray-700 mb-2 hover:text-gray-900"
+              className="flex items-center gap-2 text-sm font-semibold text-[var(--foreground)] mb-2 hover:text-[var(--foreground)]"
             >
               <svg
                 className={`w-4 h-4 transition-transform ${
@@ -496,9 +496,9 @@ export default function ChangeCard({ change, index, oldYaml, newYaml }: ChangeCa
                   isSectionUnchanged ? (
                     // Unchanged section: show once with grey background
                     <div>
-                      <h5 className="text-xs font-semibold text-gray-600 mb-1">Both Versions:</h5>
-                      <div className="bg-gray-50 border border-gray-200 rounded p-3 overflow-x-auto">
-                        <pre className="whitespace-pre-wrap text-xs font-mono text-gray-800">
+                      <h5 className="text-xs font-semibold text-[var(--brand-secondary)] mb-1">Both Versions:</h5>
+                      <div className="bg-[var(--brand-secondary)]/10 border border-[var(--brand-secondary)]/20 rounded p-3 overflow-x-auto">
+                        <pre className="whitespace-pre-wrap text-xs font-mono text-[var(--foreground)]">
                           {(() => {
                             const sectionYaml = oldSectionYaml || newSectionYaml;
                             if (!sectionYaml) return "";
@@ -518,10 +518,10 @@ export default function ChangeCard({ change, index, oldYaml, newYaml }: ChangeCa
                     // Changed section: show side-by-side (old left, new right)
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                       <div>
-                        <h5 className="text-xs font-semibold text-gray-600 mb-1">Old Version:</h5>
+                        <h5 className="text-xs font-semibold text-[var(--brand-secondary)] mb-1">Old Version:</h5>
                         <div className="bg-red-50 border border-red-200 rounded p-3 overflow-x-auto">
                           {oldSectionYaml ? (
-                            <pre className="whitespace-pre-wrap text-xs font-mono text-gray-800">
+                            <pre className="whitespace-pre-wrap text-xs font-mono text-[var(--foreground)]">
                               {oldSectionYaml
                                 .split("\n")
                                 .map((line, idx) => {
@@ -531,15 +531,15 @@ export default function ChangeCard({ change, index, oldYaml, newYaml }: ChangeCa
                                 .join("\n")}
                             </pre>
                           ) : (
-                            <div className="text-xs text-gray-500 italic font-mono">(empty)</div>
+                            <div className="text-xs text-[var(--brand-secondary)] italic font-mono">(empty)</div>
                           )}
                         </div>
                       </div>
                       <div>
-                        <h5 className="text-xs font-semibold text-gray-600 mb-1">New Version:</h5>
+                        <h5 className="text-xs font-semibold text-[var(--brand-secondary)] mb-1">New Version:</h5>
                         <div className="bg-green-50 border border-green-200 rounded p-3 overflow-x-auto">
                           {newSectionYaml ? (
-                            <pre className="whitespace-pre-wrap text-xs font-mono text-gray-800">
+                            <pre className="whitespace-pre-wrap text-xs font-mono text-[var(--foreground)]">
                               {newSectionYaml
                                 .split("\n")
                                 .map((line, idx) => {
@@ -549,7 +549,7 @@ export default function ChangeCard({ change, index, oldYaml, newYaml }: ChangeCa
                                 .join("\n")}
                             </pre>
                           ) : (
-                            <div className="text-xs text-gray-500 italic font-mono">(empty)</div>
+                            <div className="text-xs text-[var(--brand-secondary)] italic font-mono">(empty)</div>
                           )}
                         </div>
                       </div>
@@ -591,7 +591,7 @@ export default function ChangeCard({ change, index, oldYaml, newYaml }: ChangeCa
             )}
           </div>
 
-          <div className="border-t border-gray-200 pt-4">
+          <div className="border-t border-[var(--brand-secondary)]/30 pt-4">
             <button
               onClick={(e) => {
                 e.stopPropagation();
@@ -600,9 +600,9 @@ export default function ChangeCard({ change, index, oldYaml, newYaml }: ChangeCa
                   addDiscussion(changeId);
                 }
               }}
-              className="text-sm text-blue-600 hover:text-blue-800 font-medium"
+              className="text-sm text-[var(--brand-accent)] hover:underline font-medium"
             >
-              {showDiscussion ? "Hide" : "Add"} Comment
+              {showDiscussion ? "Hide" : "Add"} Comment →
             </button>
 
             {showDiscussion && (
@@ -615,7 +615,7 @@ export default function ChangeCard({ change, index, oldYaml, newYaml }: ChangeCa
                       handleAddComment();
                     }
                   }}
-                  className="w-full p-2 border border-gray-300 rounded resize-none"
+                  className="w-full p-2 border border-[var(--brand-secondary)]/40 rounded resize-none bg-[var(--brand-background)]"
                   rows={3}
                   placeholder="Add a comment about this change... (Cmd/Ctrl+Enter to submit)"
                 />
@@ -623,7 +623,7 @@ export default function ChangeCard({ change, index, oldYaml, newYaml }: ChangeCa
                   <button
                     onClick={handleAddComment}
                     disabled={!commentText.trim()}
-                    className="px-3 py-1 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed"
+                    className="px-3 py-1 bg-[var(--brand-cta-bg)] text-[var(--brand-cta-text)] rounded text-sm hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     Comment
                   </button>

--- a/ui/components/ChangePopover.tsx
+++ b/ui/components/ChangePopover.tsx
@@ -32,7 +32,7 @@ function getChangeTypeStyles(changeType: ChangeType) {
     case ChangeType.SECTION_MOVED:
       return "bg-purple-100 text-purple-800 border-purple-300";
     default:
-      return "bg-gray-100 text-gray-800 border-gray-300";
+      return "bg-[var(--brand-secondary)]/20 text-[var(--foreground)] border-[var(--brand-secondary)]/40";
   }
 }
 
@@ -127,12 +127,12 @@ export default function ChangePopover({ change, position, onClose }: ChangePopov
   return (
     <div
       ref={popoverRef}
-      className="fixed z-50 bg-white border border-gray-300 rounded-lg shadow-xl w-96 max-w-[calc(100vw-2rem)] max-h-[600px] overflow-y-auto"
+      className="fixed z-50 bg-[var(--brand-background)] border border-[var(--brand-secondary)]/40 rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.08)] w-96 max-w-[calc(100vw-2rem)] max-h-[600px] overflow-y-auto"
       style={{ left: position.x, top: position.y }}
     >
       <div className="p-4 space-y-3">
         {/* Header */}
-        <div className="flex items-start justify-between border-b border-gray-200 pb-3">
+        <div className="flex items-start justify-between border-b border-[var(--brand-secondary)]/30 pb-3">
           <div className="flex-1">
             <div className="flex items-center gap-2 mb-2">
               <span
@@ -145,13 +145,13 @@ export default function ChangePopover({ change, position, onClose }: ChangePopov
             </div>
             <div className="text-sm space-y-1">
               <div>
-                <span className="font-medium text-gray-700">Marker:</span>{" "}
-                <span className="font-mono text-gray-900">{change.marker}</span>
+                <span className="font-medium text-[var(--foreground)]">Marker:</span>{" "}
+                <span className="font-mono text-[var(--foreground)]">{change.marker}</span>
               </div>
               {hasPathChange && (
                 <div>
-                  <span className="font-medium text-gray-700">Path:</span>{" "}
-                  <span className="text-gray-600">
+                  <span className="font-medium text-[var(--foreground)]">Path:</span>{" "}
+                  <span className="text-[var(--brand-secondary)]">
                     {formatMarkerPath(change.old_marker_path)} →{" "}
                     {formatMarkerPath(change.new_marker_path)}
                   </span>
@@ -161,7 +161,7 @@ export default function ChangePopover({ change, position, onClose }: ChangePopov
           </div>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 transition-colors"
+            className="text-[var(--brand-secondary)] hover:text-[var(--foreground)] transition-colors"
             aria-label="Close"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -177,31 +177,31 @@ export default function ChangePopover({ change, position, onClose }: ChangePopov
 
         {/* Change details */}
         {(hasTitleChange || hasContentChange) && (
-          <div className="border-b border-gray-200 pb-3 space-y-2">
+          <div className="border-b border-[var(--brand-secondary)]/30 pb-3 space-y-2">
             {hasTitleChange && (
               <div>
-                <h4 className="text-xs font-semibold text-gray-700 mb-1">Title Change:</h4>
+                <h4 className="text-xs font-semibold text-[var(--foreground)] mb-1">Title Change:</h4>
                 <div className="grid grid-cols-2 gap-2 text-xs">
                   <div className="bg-red-50 border border-red-200 rounded p-2">
-                    <div className="font-mono text-gray-800">{change.old_title || "(empty)"}</div>
+                    <div className="font-mono text-[var(--foreground)]">{change.old_title || "(empty)"}</div>
                   </div>
                   <div className="bg-green-50 border border-green-200 rounded p-2">
-                    <div className="font-mono text-gray-800">{change.new_title || "(empty)"}</div>
+                    <div className="font-mono text-[var(--foreground)]">{change.new_title || "(empty)"}</div>
                   </div>
                 </div>
               </div>
             )}
             {hasContentChange && (
               <div>
-                <h4 className="text-xs font-semibold text-gray-700 mb-1">Content Change:</h4>
+                <h4 className="text-xs font-semibold text-[var(--foreground)] mb-1">Content Change:</h4>
                 <div className="grid grid-cols-2 gap-2 text-xs max-h-32 overflow-y-auto">
                   <div className="bg-red-50 border border-red-200 rounded p-2">
-                    <pre className="whitespace-pre-wrap font-mono text-gray-800 text-xs">
+                    <pre className="whitespace-pre-wrap font-mono text-[var(--foreground)] text-xs">
                       {change.old_content || "(empty)"}
                     </pre>
                   </div>
                   <div className="bg-green-50 border border-green-200 rounded p-2">
-                    <pre className="whitespace-pre-wrap font-mono text-gray-800 text-xs">
+                    <pre className="whitespace-pre-wrap font-mono text-[var(--foreground)] text-xs">
                       {change.new_content || "(empty)"}
                     </pre>
                   </div>
@@ -213,7 +213,7 @@ export default function ChangePopover({ change, position, onClose }: ChangePopov
 
         {/* Discussion */}
         <div className="space-y-2">
-          <h4 className="text-sm font-semibold text-gray-700">Discussion</h4>
+          <h4 className="text-sm font-semibold text-[var(--foreground)]">Discussion</h4>
           <textarea
             value={commentText}
             onChange={(e) => setCommentText(e.target.value)}
@@ -222,14 +222,14 @@ export default function ChangePopover({ change, position, onClose }: ChangePopov
                 handleAddComment();
               }
             }}
-            className="w-full p-2 border border-gray-300 rounded resize-none text-sm"
+            className="w-full p-2 border border-[var(--brand-secondary)]/40 rounded resize-none text-sm bg-[var(--brand-background)]"
             rows={3}
             placeholder="Add a comment about this change... (Cmd/Ctrl+Enter to submit)"
           />
           <button
             onClick={handleAddComment}
             disabled={!commentText.trim()}
-            className="px-3 py-1 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed"
+            className="px-3 py-1 bg-[var(--brand-cta-bg)] text-[var(--brand-cta-text)] rounded text-sm hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Comment
           </button>

--- a/ui/components/DemoSection.tsx
+++ b/ui/components/DemoSection.tsx
@@ -90,24 +90,24 @@ function ExampleButton({ example, isSelected, isLoading, onClick, disabled }: Ex
       onClick={onClick}
       disabled={disabled}
       className={`
-        p-3 rounded-lg border-2 text-left transition-all
+        p-3 rounded-lg border-2 text-left transition-all shadow-[0_4px_12px_rgba(0,0,0,0.08)]
         ${
           isSelected
-            ? "border-[var(--brand-primary)] bg-blue-50"
-            : "border-gray-200 bg-white hover:border-gray-300 hover:shadow-md"
+            ? "border-[var(--brand-accent)] bg-[var(--brand-accent)]/10"
+            : "border-[var(--brand-secondary)]/30 bg-[var(--brand-background)] hover:border-[var(--brand-secondary)]/50 hover:shadow-md"
         }
         ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}
-        focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)] focus:ring-offset-2
+        focus:outline-none focus:ring-2 focus:ring-[var(--brand-accent)] focus:ring-offset-2
       `}
       aria-label={`Load ${example.name} example`}
     >
       <div className="flex items-start justify-between mb-1.5">
-        <h4 className="font-semibold text-gray-900 text-sm">
+        <h4 className="font-normal text-[var(--foreground)] text-sm" style={{ fontFamily: "var(--font-serif), serif" }}>
           {example.name}
         </h4>
         {isLoading && (
           <svg
-            className="animate-spin h-4 w-4 text-[var(--brand-primary)]"
+            className="animate-spin h-4 w-4 text-[var(--brand-accent)]"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"
@@ -128,14 +128,14 @@ function ExampleButton({ example, isSelected, isLoading, onClick, disabled }: Ex
           </svg>
         )}
       </div>
-      <p className="text-xs text-gray-600 mb-2">
+      <p className="text-xs text-[var(--brand-secondary)] mb-2">
         {example.description}
       </p>
       <div className="flex flex-wrap gap-1">
         {example.diffTypes.map((type) => (
           <span
             key={type}
-            className="inline-block px-1.5 py-0.5 text-xs bg-gray-100 text-gray-700 rounded"
+            className="inline-block px-1.5 py-0.5 text-xs bg-[var(--brand-secondary)]/15 text-[var(--foreground)] rounded"
           >
             {type}
           </span>
@@ -241,20 +241,20 @@ export default function DemoSection({
   };
 
   return (
-    <div className="bg-gray-50 border-b border-gray-200 py-4">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div className="bg-[var(--brand-background)] border-b border-[var(--brand-secondary)]/30 py-6 shadow-[0_4px_12px_rgba(0,0,0,0.08)]">
+      <div className="max-w-[1200px] mx-auto px-4 sm:px-6 lg:px-8">
         {/* Service Explanation - Always visible, compact */}
         <div className="mb-4">
-          <h2 className="text-xl font-semibold text-gray-900 mb-2">
+          <h2 className="text-xl font-normal text-[var(--foreground)] mb-2" style={{ fontFamily: "var(--font-serif), serif" }}>
             What is yamly?
           </h2>
-          <p className="text-gray-700 text-sm leading-relaxed">
+          <p className="text-[var(--brand-secondary)] text-sm leading-relaxed">
             <strong>yamly</strong> reads YAML as structured data rather than plain text. It highlights meaningful changes and filters out noise, making it easier to review config updates, infrastructure changes, and YAML produced or rewritten by LLM-powered tools.
           </p>
         </div>
 
         {/* Mode Selector - At the top */}
-        <div className="mb-4 bg-white rounded-lg p-4 border border-gray-200">
+        <div className="mb-4 bg-[var(--brand-background)] rounded-lg p-4 border border-[var(--brand-secondary)]/30 shadow-[0_4px_12px_rgba(0,0,0,0.08)]">
           <ModeSelector
             mode={mode}
             onModeChange={onModeChange}
@@ -264,7 +264,7 @@ export default function DemoSection({
           />
           {isModeLocked && (
             <div className="mt-3 flex items-center justify-between">
-              <p className="text-xs text-gray-600">
+              <p className="text-xs text-[var(--brand-secondary)]">
                 Mode is locked to match the selected example. Clear the example to change mode.
               </p>
               <button
@@ -274,9 +274,9 @@ export default function DemoSection({
                   setSelectedExample(null);
                   onClearExample();
                 }}
-                className="text-xs text-[var(--brand-primary)] hover:underline"
+                className="text-xs text-[var(--brand-accent)] hover:underline"
               >
-                Clear & Unlock
+                Clear & Unlock →
               </button>
             </div>
           )}
@@ -285,15 +285,15 @@ export default function DemoSection({
         {/* Accordion Sections */}
         <div className="space-y-2">
           {/* Input Requirements Accordion */}
-          <div className="border border-gray-200 rounded-lg bg-white overflow-hidden">
+          <div className="border border-[var(--brand-secondary)]/30 rounded-lg bg-[var(--brand-background)] overflow-hidden shadow-[0_4px_12px_rgba(0,0,0,0.08)]">
             <button
               onClick={() => toggleSection("requirements")}
-              className="w-full px-4 py-3 flex items-center justify-between hover:bg-gray-50 transition-colors text-left"
+              className="w-full px-4 py-3 flex items-center justify-between hover:bg-[var(--brand-accent)]/10 transition-colors text-left"
               aria-expanded={expandedSection === "requirements"}
             >
               <div className="flex items-center gap-2">
                 <svg
-                  className="h-5 w-5 text-blue-600 flex-shrink-0"
+                  className="h-5 w-5 text-[var(--brand-accent)] flex-shrink-0"
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke="currentColor"
@@ -305,12 +305,12 @@ export default function DemoSection({
                     d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
                   />
                 </svg>
-                <span className="font-medium text-gray-900">
+                <span className="font-medium text-[var(--foreground)]">
                   Input Requirements
                 </span>
               </div>
               <svg
-                className={`h-5 w-5 text-gray-500 transition-transform ${
+                className={`h-5 w-5 text-[var(--brand-secondary)] transition-transform ${
                   expandedSection === "requirements" ? "rotate-180" : ""
                 }`}
                 fill="none"
@@ -326,7 +326,7 @@ export default function DemoSection({
               </svg>
             </button>
             {expandedSection === "requirements" && (
-              <div className="px-4 pb-4 border-t border-gray-200 bg-blue-50">
+              <div className="px-4 pb-4 border-t border-[var(--brand-secondary)]/30 bg-[var(--brand-accent)]/10">
                 {mode === "auto" ? (
                   // Show both modes when auto-detect
                   <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -478,7 +478,7 @@ export default function DemoSection({
                     </div>
 
                     {/* Schema Reference Box */}
-                    <div className="mt-4 p-4 bg-white border border-blue-200 rounded-lg">
+                    <div className="mt-4 p-4 bg-[var(--brand-background)] border border-[var(--brand-accent)]/50 rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.08)]">
                       <div className="flex items-center justify-between mb-2">
                         <h5 className="font-semibold text-blue-900 text-sm flex items-center gap-2">
                           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -488,7 +488,7 @@ export default function DemoSection({
                         </h5>
                         <button
                           onClick={() => setShowSchema(true)}
-                          className="text-xs text-[var(--brand-primary)] hover:underline flex items-center gap-1"
+                          className="text-xs text-[var(--brand-accent)] hover:underline flex items-center gap-1"
                         >
                           View Full Schema →
                         </button>
@@ -504,15 +504,15 @@ export default function DemoSection({
           </div>
 
           {/* Example Documents Accordion */}
-          <div className="border border-gray-200 rounded-lg bg-white overflow-hidden">
+          <div className="border border-[var(--brand-secondary)]/30 rounded-lg bg-[var(--brand-background)] overflow-hidden shadow-[0_4px_12px_rgba(0,0,0,0.08)]">
             <button
               onClick={() => toggleSection("examples")}
-              className="w-full px-4 py-3 flex items-center justify-between hover:bg-gray-50 transition-colors text-left"
+              className="w-full px-4 py-3 flex items-center justify-between hover:bg-[var(--brand-accent)]/10 transition-colors text-left"
               aria-expanded={expandedSection === "examples"}
             >
               <div className="flex items-center gap-2">
                 <svg
-                  className="h-5 w-5 text-[var(--brand-primary)] flex-shrink-0"
+                  className="h-5 w-5 text-[var(--brand-accent)] flex-shrink-0"
                   fill="none"
                   viewBox="0 0 24 24"
                   stroke="currentColor"
@@ -524,12 +524,12 @@ export default function DemoSection({
                     d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
                   />
                 </svg>
-                <span className="font-medium text-gray-900">
-                  Try Example Documents
+                <span className="font-medium text-[var(--foreground)]">
+                  Try Example Documents →
                 </span>
               </div>
               <svg
-                className={`h-5 w-5 text-gray-500 transition-transform ${
+                className={`h-5 w-5 text-[var(--brand-secondary)] transition-transform ${
                   expandedSection === "examples" ? "rotate-180" : ""
                 }`}
                 fill="none"
@@ -545,7 +545,7 @@ export default function DemoSection({
               </svg>
             </button>
             {expandedSection === "examples" && (
-              <div className="px-4 pb-4 border-t border-gray-200">
+              <div className="px-4 pb-4 border-t border-[var(--brand-secondary)]/30">
                 {filteredExamples.length === 0 ? (
                   <div className="mt-3 p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
                     <p className="text-sm text-yellow-800">
@@ -558,7 +558,7 @@ export default function DemoSection({
                       // Show both categories when in auto mode
                       <>
                         <div className="mb-4">
-                          <h4 className="text-sm font-semibold text-gray-700 mb-2 flex items-center gap-2">
+                          <h4 className="text-sm font-medium text-[var(--foreground)] mb-2 flex items-center gap-2">
                             <span className="w-2 h-2 rounded-full bg-green-500"></span>
                             Generic YAML
                           </h4>
@@ -576,7 +576,7 @@ export default function DemoSection({
                           </div>
                         </div>
                         <div>
-                          <h4 className="text-sm font-semibold text-gray-700 mb-2 flex items-center gap-2">
+                          <h4 className="text-sm font-medium text-[var(--foreground)] mb-2 flex items-center gap-2">
                             <span className="w-2 h-2 rounded-full bg-purple-500"></span>
                             Legal Documents
                           </h4>

--- a/ui/components/DemoSection.tsx
+++ b/ui/components/DemoSection.tsx
@@ -331,47 +331,47 @@ export default function DemoSection({
                   // Show both modes when auto-detect
                   <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div>
-                      <h4 className="font-semibold text-blue-900 mb-2 text-sm">General YAML Mode</h4>
-                      <ul className="text-sm text-blue-800 space-y-1.5">
+                      <h4 className="font-semibold text-[var(--foreground)] mb-2 text-sm">General YAML Mode</h4>
+                      <ul className="text-sm text-[var(--foreground)] space-y-1.5">
                         <li className="flex items-start gap-2">
-                          <span className="text-blue-600 mt-0.5">•</span>
+                          <span className="text-[var(--brand-accent)] mt-0.5">•</span>
                           <span>Any valid YAML file works</span>
                         </li>
                         <li className="flex items-start gap-2">
-                          <span className="text-blue-600 mt-0.5">•</span>
+                          <span className="text-[var(--brand-accent)] mt-0.5">•</span>
                           <span>Uses path-based change tracking</span>
                         </li>
                         <li className="flex items-start gap-2">
-                          <span className="text-blue-600 mt-0.5">•</span>
+                          <span className="text-[var(--brand-accent)] mt-0.5">•</span>
                           <span>Auto-detects array item identity</span>
                         </li>
                         <li className="flex items-start gap-2">
-                          <span className="text-blue-600 mt-0.5">•</span>
+                          <span className="text-[var(--brand-accent)] mt-0.5">•</span>
                           <span>Great for configs, K8s manifests</span>
                         </li>
                       </ul>
                     </div>
                     <div>
-                      <h4 className="font-semibold text-blue-900 mb-2 text-sm">Legal Document Mode</h4>
-                      <ul className="text-sm text-blue-800 space-y-1.5">
+                      <h4 className="font-semibold text-[var(--foreground)] mb-2 text-sm">Legal Document Mode</h4>
+                      <ul className="text-sm text-[var(--foreground)] space-y-1.5">
                         <li className="flex items-start gap-2">
-                          <span className="text-blue-600 mt-0.5">•</span>
+                          <span className="text-[var(--brand-accent)] mt-0.5">•</span>
                           <span>
-                            Requires <code className="bg-blue-100 px-1 rounded text-xs">document:</code> top-level key
+                            Requires <code className="bg-[var(--brand-accent)]/10 px-1 rounded text-xs">document:</code> top-level key
                           </span>
                         </li>
                         <li className="flex items-start gap-2">
-                          <span className="text-blue-600 mt-0.5">•</span>
+                          <span className="text-[var(--brand-accent)] mt-0.5">•</span>
                           <span>
-                            Sections need <code className="bg-blue-100 px-1 rounded text-xs">marker</code> field
+                            Sections need <code className="bg-[var(--brand-accent)]/10 px-1 rounded text-xs">marker</code> field
                           </span>
                         </li>
                         <li className="flex items-start gap-2">
-                          <span className="text-blue-600 mt-0.5">•</span>
+                          <span className="text-[var(--brand-accent)] mt-0.5">•</span>
                           <span>Schema validation built-in</span>
                         </li>
                         <li className="flex items-start gap-2">
-                          <span className="text-blue-600 mt-0.5">•</span>
+                          <span className="text-[var(--brand-accent)] mt-0.5">•</span>
                           <span>Hebrew legal documents</span>
                         </li>
                       </ul>
@@ -380,22 +380,22 @@ export default function DemoSection({
                 ) : mode === "general" ? (
                   // Show only General YAML mode
                   <div className="mt-3">
-                    <h4 className="font-semibold text-blue-900 mb-2 text-sm">General YAML Mode Requirements</h4>
-                    <ul className="text-sm text-blue-800 space-y-1.5">
+                    <h4 className="font-semibold text-[var(--foreground)] mb-2 text-sm">General YAML Mode Requirements</h4>
+                    <ul className="text-sm text-[var(--foreground)] space-y-1.5">
                       <li className="flex items-start gap-2">
-                        <span className="text-blue-600 mt-0.5">•</span>
+                        <span className="text-[var(--brand-accent)] mt-0.5">•</span>
                         <span>Any valid YAML file works - no specific structure required</span>
                       </li>
                       <li className="flex items-start gap-2">
-                        <span className="text-blue-600 mt-0.5">•</span>
-                        <span>Uses path-based change tracking (e.g., <code className="bg-blue-100 px-1 rounded text-xs">spec.replicas</code>)</span>
+                        <span className="text-[var(--brand-accent)] mt-0.5">•</span>
+                        <span>Uses path-based change tracking (e.g., <code className="bg-[var(--brand-accent)]/10 px-1 rounded text-xs">spec.replicas</code>)</span>
                       </li>
                       <li className="flex items-start gap-2">
-                        <span className="text-blue-600 mt-0.5">•</span>
-                        <span>Auto-detects array item identity by common fields (<code className="bg-blue-100 px-1 rounded text-xs">id</code>, <code className="bg-blue-100 px-1 rounded text-xs">name</code>, <code className="bg-blue-100 px-1 rounded text-xs">key</code>)</span>
+                        <span className="text-[var(--brand-accent)] mt-0.5">•</span>
+                        <span>Auto-detects array item identity by common fields (<code className="bg-[var(--brand-accent)]/10 px-1 rounded text-xs">id</code>, <code className="bg-[var(--brand-accent)]/10 px-1 rounded text-xs">name</code>, <code className="bg-[var(--brand-accent)]/10 px-1 rounded text-xs">key</code>)</span>
                       </li>
                       <li className="flex items-start gap-2">
-                        <span className="text-blue-600 mt-0.5">•</span>
+                        <span className="text-[var(--brand-accent)] mt-0.5">•</span>
                         <span>Perfect for config files, Kubernetes manifests, CI/CD pipelines, and more</span>
                       </li>
                     </ul>
@@ -403,76 +403,76 @@ export default function DemoSection({
                 ) : (
                   // Show only Legal Document mode with schema reference
                   <div className="mt-3">
-                    <h4 className="font-semibold text-blue-900 mb-2 text-sm">Legal Document Mode - Schema Requirements</h4>
+                    <h4 className="font-semibold text-[var(--foreground)] mb-2 text-sm">Legal Document Mode - Schema Requirements</h4>
 
                     <div className="space-y-3">
                       <div>
-                        <h5 className="text-xs font-semibold text-blue-800 mb-1.5">Document (recommended fields):</h5>
-                        <p className="text-xs text-blue-700 mb-2 italic">Note: Only <code className="bg-blue-100 px-1 rounded text-xs">sections</code> is required. All metadata fields are optional but recommended.</p>
-                        <ul className="text-sm text-blue-800 space-y-1">
+                        <h5 className="text-xs font-semibold text-[var(--foreground)] mb-1.5">Document (recommended fields):</h5>
+                        <p className="text-xs text-[var(--brand-secondary)] mb-2 italic">Note: Only <code className="bg-[var(--brand-accent)]/10 px-1 rounded text-xs">sections</code> is required. All metadata fields are optional but recommended.</p>
+                        <ul className="text-sm text-[var(--foreground)] space-y-1">
                           <li className="flex items-start gap-2">
-                            <span className="text-blue-600 mt-0.5">•</span>
+                            <span className="text-[var(--brand-accent)] mt-0.5">•</span>
                             <span>
-                              <code className="bg-blue-100 px-1 rounded text-xs">id</code>: <span className="text-blue-600">(Optional)</span> String identifier for tracking (UUID or custom)
+                              <code className="bg-[var(--brand-accent)]/10 px-1 rounded text-xs">id</code>: <span className="text-[var(--brand-accent)]">(Optional)</span> String identifier for tracking (UUID or custom)
                             </span>
                           </li>
                           <li className="flex items-start gap-2">
-                            <span className="text-blue-600 mt-0.5">•</span>
+                            <span className="text-[var(--brand-accent)] mt-0.5">•</span>
                             <span>
-                              <code className="bg-blue-100 px-1 rounded text-xs">title</code>: <span className="text-blue-600">(Optional)</span> Document title for human readability
+                              <code className="bg-[var(--brand-accent)]/10 px-1 rounded text-xs">title</code>: <span className="text-[var(--brand-accent)]">(Optional)</span> Document title for human readability
                             </span>
                           </li>
                           <li className="flex items-start gap-2">
-                            <span className="text-blue-600 mt-0.5">•</span>
+                            <span className="text-[var(--brand-accent)] mt-0.5">•</span>
                             <span>
-                              <code className="bg-blue-100 px-1 rounded text-xs">type</code>: <span className="text-blue-600">(Optional)</span> Any string value (recommended for organization and filtering). Common examples: <code className="bg-blue-100 px-0.5 rounded text-xs">'law'</code>, <code className="bg-blue-100 px-0.5 rounded text-xs">'regulation'</code>, <code className="bg-blue-100 px-0.5 rounded text-xs">'directive'</code>, <code className="bg-blue-100 px-0.5 rounded text-xs">'circular'</code>, <code className="bg-blue-100 px-0.5 rounded text-xs">'policy'</code>, <code className="bg-blue-100 px-0.5 rounded text-xs">'other'</code>
+                              <code className="bg-[var(--brand-accent)]/10 px-1 rounded text-xs">type</code>: <span className="text-[var(--brand-accent)]">(Optional)</span> Any string value (recommended for organization and filtering). Common examples: <code className="bg-[var(--brand-accent)]/10 px-0.5 rounded text-xs">'law'</code>, <code className="bg-[var(--brand-accent)]/10 px-0.5 rounded text-xs">'regulation'</code>, <code className="bg-[var(--brand-accent)]/10 px-0.5 rounded text-xs">'directive'</code>, <code className="bg-[var(--brand-accent)]/10 px-0.5 rounded text-xs">'circular'</code>, <code className="bg-[var(--brand-accent)]/10 px-0.5 rounded text-xs">'policy'</code>, <code className="bg-[var(--brand-accent)]/10 px-0.5 rounded text-xs">'other'</code>
                             </span>
                           </li>
                           <li className="flex items-start gap-2">
-                            <span className="text-blue-600 mt-0.5">•</span>
+                            <span className="text-[var(--brand-accent)] mt-0.5">•</span>
                             <span>
-                              <code className="bg-blue-100 px-1 rounded text-xs">language</code>: <span className="text-blue-600">(Optional)</span> Must be <code className="bg-blue-100 px-0.5 rounded text-xs">'hebrew'</code> if provided
+                              <code className="bg-[var(--brand-accent)]/10 px-1 rounded text-xs">language</code>: <span className="text-[var(--brand-accent)]">(Optional)</span> Must be <code className="bg-[var(--brand-accent)]/10 px-0.5 rounded text-xs">'hebrew'</code> if provided
                             </span>
                           </li>
                           <li className="flex items-start gap-2">
-                            <span className="text-blue-600 mt-0.5">•</span>
+                            <span className="text-[var(--brand-accent)] mt-0.5">•</span>
                             <span>
-                              <code className="bg-blue-100 px-1 rounded text-xs">version</code>: <span className="text-blue-600">(Optional)</span> Object with optional <code className="bg-blue-100 px-0.5 rounded text-xs">number</code> field
+                              <code className="bg-[var(--brand-accent)]/10 px-1 rounded text-xs">version</code>: <span className="text-[var(--brand-accent)]">(Optional)</span> Object with optional <code className="bg-[var(--brand-accent)]/10 px-0.5 rounded text-xs">number</code> field
                             </span>
                           </li>
                           <li className="flex items-start gap-2">
-                            <span className="text-blue-600 mt-0.5">•</span>
+                            <span className="text-[var(--brand-accent)] mt-0.5">•</span>
                             <span>
-                              <code className="bg-blue-100 px-1 rounded text-xs">source</code>: <span className="text-blue-600">(Optional)</span> Object with optional <code className="bg-blue-100 px-0.5 rounded text-xs">url</code> and <code className="bg-blue-100 px-0.5 rounded text-xs">fetched_at</code> fields
+                              <code className="bg-[var(--brand-accent)]/10 px-1 rounded text-xs">source</code>: <span className="text-[var(--brand-accent)]">(Optional)</span> Object with optional <code className="bg-[var(--brand-accent)]/10 px-0.5 rounded text-xs">url</code> and <code className="bg-[var(--brand-accent)]/10 px-0.5 rounded text-xs">fetched_at</code> fields
                             </span>
                           </li>
                           <li className="flex items-start gap-2">
-                            <span className="text-blue-600 mt-0.5">•</span>
+                            <span className="text-[var(--brand-accent)] mt-0.5">•</span>
                             <span>
-                              <code className="bg-blue-100 px-1 rounded text-xs font-semibold">sections</code>: <span className="text-blue-700 font-semibold">(Required)</span> Array of section objects
+                              <code className="bg-[var(--brand-accent)]/10 px-1 rounded text-xs font-semibold">sections</code>: <span className="text-[var(--brand-secondary)] font-semibold">(Required)</span> Array of section objects
                             </span>
                           </li>
                         </ul>
                       </div>
 
                       <div>
-                        <h5 className="text-xs font-semibold text-blue-800 mb-1.5">Section (required fields):</h5>
-                        <ul className="text-sm text-blue-800 space-y-1">
+                        <h5 className="text-xs font-semibold text-[var(--foreground)] mb-1.5">Section (required fields):</h5>
+                        <ul className="text-sm text-[var(--foreground)] space-y-1">
                           <li className="flex items-start gap-2">
-                            <span className="text-blue-600 mt-0.5">•</span>
+                            <span className="text-[var(--brand-accent)] mt-0.5">•</span>
                             <span>
-                              <code className="bg-blue-100 px-1 rounded text-xs">marker</code>: Unique structural marker (e.g., "1", "1.א", "(b)") - must be unique at same nesting level
+                              <code className="bg-[var(--brand-accent)]/10 px-1 rounded text-xs">marker</code>: Unique structural marker (e.g., "1", "1.א", "(b)") - must be unique at same nesting level
                             </span>
                           </li>
                           <li className="flex items-start gap-2">
-                            <span className="text-blue-600 mt-0.5">•</span>
+                            <span className="text-[var(--brand-accent)] mt-0.5">•</span>
                             <span>
-                              <code className="bg-blue-100 px-1 rounded text-xs">sections</code>: Array of nested sections (can be empty)
+                              <code className="bg-[var(--brand-accent)]/10 px-1 rounded text-xs">sections</code>: Array of nested sections (can be empty)
                             </span>
                           </li>
                         </ul>
-                        <p className="text-xs text-blue-700 mt-1.5 italic">
-                          Optional: <code className="bg-blue-100 px-0.5 rounded text-xs">id</code> (auto-generated if not provided), <code className="bg-blue-100 px-0.5 rounded text-xs">title</code>, <code className="bg-blue-100 px-0.5 rounded text-xs">content</code>
+                        <p className="text-xs text-[var(--brand-secondary)] mt-1.5 italic">
+                          Optional: <code className="bg-[var(--brand-accent)]/10 px-0.5 rounded text-xs">id</code> (auto-generated if not provided), <code className="bg-[var(--brand-accent)]/10 px-0.5 rounded text-xs">title</code>, <code className="bg-[var(--brand-accent)]/10 px-0.5 rounded text-xs">content</code>
                         </p>
                       </div>
                     </div>
@@ -480,7 +480,7 @@ export default function DemoSection({
                     {/* Schema Reference Box */}
                     <div className="mt-4 p-4 bg-[var(--brand-background)] border border-[var(--brand-accent)]/50 rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.08)]">
                       <div className="flex items-center justify-between mb-2">
-                        <h5 className="font-semibold text-blue-900 text-sm flex items-center gap-2">
+                        <h5 className="font-semibold text-[var(--foreground)] text-sm flex items-center gap-2">
                           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
                           </svg>
@@ -493,8 +493,8 @@ export default function DemoSection({
                           View Full Schema →
                         </button>
                       </div>
-                      <p className="text-xs text-blue-800">
-                        Legal documents must follow the OpenSpec schema with recursive sections. Each section contains a <code className="bg-blue-100 px-1 rounded">marker</code> (required), optional <code className="bg-blue-100 px-1 rounded">title</code>, <code className="bg-blue-100 px-1 rounded">content</code>, and nested <code className="bg-blue-100 px-1 rounded">sections</code>.
+                      <p className="text-xs text-[var(--foreground)]">
+                        Legal documents must follow the OpenSpec schema with recursive sections. Each section contains a <code className="bg-[var(--brand-accent)]/10 px-1 rounded">marker</code> (required), optional <code className="bg-[var(--brand-accent)]/10 px-1 rounded">title</code>, <code className="bg-[var(--brand-accent)]/10 px-1 rounded">content</code>, and nested <code className="bg-[var(--brand-accent)]/10 px-1 rounded">sections</code>.
                       </p>
                     </div>
                   </div>

--- a/ui/components/DiffSummary.tsx
+++ b/ui/components/DiffSummary.tsx
@@ -84,7 +84,7 @@ export default function DiffSummary({ diff }: DiffSummaryProps) {
           )}
           {diff.key_renamed_count > 0 && (
             <div className="flex items-center gap-2">
-              <span className="text-blue-600 font-medium">
+              <span className="text-[var(--brand-accent)] font-medium">
                 ↻{diff.key_renamed_count} keys renamed
               </span>
             </div>

--- a/ui/components/DiffSummary.tsx
+++ b/ui/components/DiffSummary.tsx
@@ -14,9 +14,9 @@ export default function DiffSummary({ diff }: DiffSummaryProps) {
   if (isDocumentDiff(diff)) {
     // Document diff summary
     return (
-      <div className="bg-gray-50 border-b border-gray-200 px-4 sm:px-6 py-4">
+      <div className="bg-[var(--brand-background)] border-b border-[var(--brand-secondary)]/30 px-4 sm:px-6 py-4">
         <div className="flex flex-wrap items-center gap-3 sm:gap-6 text-sm">
-          <span className="font-semibold text-gray-700">Changes Summary:</span>
+          <span className="font-semibold text-[var(--foreground)]">Changes Summary:</span>
           <div className="flex items-center gap-2">
             <span className="text-green-600 font-medium">
               +{diff.added_count} added
@@ -37,7 +37,7 @@ export default function DiffSummary({ diff }: DiffSummaryProps) {
               ↔{diff.moved_count} moved
             </span>
           </div>
-          <div className="ml-auto text-gray-500">
+          <div className="ml-auto text-[var(--brand-secondary)]">
             Total: {diff.added_count + diff.deleted_count + diff.modified_count + diff.moved_count} changes
           </div>
         </div>
@@ -58,9 +58,9 @@ export default function DiffSummary({ diff }: DiffSummaryProps) {
       diff.type_changed_count;
 
     return (
-      <div className="bg-gray-50 border-b border-gray-200 px-4 sm:px-6 py-4">
+      <div className="bg-[var(--brand-background)] border-b border-[var(--brand-secondary)]/30 px-4 sm:px-6 py-4">
         <div className="flex flex-wrap items-center gap-3 sm:gap-6 text-sm">
-          <span className="font-semibold text-gray-700">Changes Summary:</span>
+          <span className="font-semibold text-[var(--foreground)]">Changes Summary:</span>
           {diff.value_changed_count > 0 && (
             <div className="flex items-center gap-2">
               <span className="text-yellow-600 font-medium">
@@ -131,7 +131,7 @@ export default function DiffSummary({ diff }: DiffSummaryProps) {
               </span>
             </div>
           )}
-          <div className="ml-auto text-gray-500">
+          <div className="ml-auto text-[var(--brand-secondary)]">
             Total: {totalChanges} changes
           </div>
         </div>

--- a/ui/components/DiffView.tsx
+++ b/ui/components/DiffView.tsx
@@ -42,7 +42,7 @@ export default function DiffView({ diff, oldYaml, newYaml }: DiffViewProps) {
   if (diff.changes.length === 0) {
     return (
       <div className="text-center py-12">
-        <p className="text-gray-500 text-lg">No changes detected between the two versions.</p>
+        <p className="text-[var(--brand-secondary)] text-lg">No changes detected between the two versions.</p>
       </div>
     );
   }
@@ -52,7 +52,7 @@ export default function DiffView({ diff, oldYaml, newYaml }: DiffViewProps) {
       <DiffSummary diff={diff} />
 
       {/* View toggle */}
-      <div className="border-b border-gray-200 bg-white">
+      <div className="border-b border-[var(--brand-secondary)]/30 bg-[var(--brand-background)] rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.08)]">
         <div className="px-4 sm:px-6">
           <nav className="flex space-x-8">
             <Tooltip content="Side-by-side comparison of old and new versions">
@@ -60,8 +60,8 @@ export default function DiffView({ diff, oldYaml, newYaml }: DiffViewProps) {
                 onClick={() => handleViewChange("split")}
                 className={`py-3 px-1 border-b-2 font-medium text-sm transition-colors ${
                   viewType === "split"
-                    ? "border-blue-500 text-blue-600"
-                    : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+                    ? "border-[var(--brand-cta-bg)] text-[var(--foreground)]"
+                    : "border-transparent text-[var(--brand-secondary)] hover:text-[var(--foreground)] hover:border-[var(--brand-secondary)]/40"
                 }`}
                 aria-label="Switch to split view"
               >
@@ -73,8 +73,8 @@ export default function DiffView({ diff, oldYaml, newYaml }: DiffViewProps) {
                 onClick={() => handleViewChange("cards")}
                 className={`py-3 px-1 border-b-2 font-medium text-sm transition-colors ${
                   viewType === "cards"
-                    ? "border-blue-500 text-blue-600"
-                    : "border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+                    ? "border-[var(--brand-cta-bg)] text-[var(--foreground)]"
+                    : "border-transparent text-[var(--brand-secondary)] hover:text-[var(--foreground)] hover:border-[var(--brand-secondary)]/40"
                 }`}
                 aria-label="Switch to cards view"
               >

--- a/ui/components/DiscussionThread.tsx
+++ b/ui/components/DiscussionThread.tsx
@@ -49,15 +49,15 @@ export default function DiscussionThread({
     return (
       <div
         key={comment.id}
-        className={`${depth > 0 ? "ml-8 mt-3 border-l-2 border-gray-200 pl-4" : ""}`}
+        className={`${depth > 0 ? "ml-8 mt-3 border-l-2 border-[var(--brand-secondary)]/30 pl-4" : ""}`}
       >
-        <div className="bg-white border border-gray-200 rounded-lg p-3">
+        <div className="bg-[var(--brand-background)] border border-[var(--brand-secondary)]/30 rounded-lg p-3 shadow-[0_4px_12px_rgba(0,0,0,0.08)]">
           {isEditing ? (
             <div>
               <textarea
                 value={editText}
                 onChange={(e) => setEditText(e.target.value)}
-                className="w-full p-2 border border-gray-300 rounded resize-none"
+                className="w-full p-2 border border-[var(--brand-secondary)]/40 rounded resize-none bg-[var(--brand-background)]"
                 rows={3}
                 autoFocus
               />
@@ -73,7 +73,7 @@ export default function DiscussionThread({
                     setEditingId(null);
                     setEditText("");
                   }}
-                  className="px-3 py-1 bg-gray-200 text-gray-700 rounded text-sm hover:bg-gray-300"
+                  className="px-3 py-1 bg-[var(--brand-secondary)]/20 text-[var(--foreground)] rounded text-sm hover:bg-[var(--brand-secondary)]/30"
                 >
                   Cancel
                 </button>
@@ -82,13 +82,13 @@ export default function DiscussionThread({
           ) : (
             <>
               <div className="flex items-start justify-between">
-                <p className="text-sm text-gray-800 whitespace-pre-wrap">
+                <p className="text-sm text-[var(--foreground)] whitespace-pre-wrap">
                   {comment.text}
                 </p>
                 <div className="flex gap-2 ml-2">
                   <button
                     onClick={() => startEdit(comment)}
-                    className="text-xs text-gray-500 hover:text-gray-700"
+                    className="text-xs text-[var(--brand-secondary)] hover:text-[var(--foreground)]"
                   >
                     Edit
                   </button>
@@ -101,7 +101,7 @@ export default function DiscussionThread({
                 </div>
               </div>
               <div className="mt-2 flex items-center justify-between">
-                <span className="text-xs text-gray-500">
+                <span className="text-xs text-[var(--brand-secondary)]">
                   {new Date(comment.timestamp).toLocaleString()}
                 </span>
                 {depth === 0 && (
@@ -162,7 +162,7 @@ export default function DiscussionThread({
   return (
     <div className="mt-4 space-y-3">
       {comments.length === 0 ? (
-        <p className="text-sm text-gray-500 italic">No comments yet.</p>
+        <p className="text-sm text-[var(--brand-secondary)] italic">No comments yet.</p>
       ) : (
         comments.map((comment) => renderComment(comment))
       )}

--- a/ui/components/DocumentationLinks.tsx
+++ b/ui/components/DocumentationLinks.tsx
@@ -63,7 +63,7 @@ export default function DocumentationLinks({
         onMouseLeave={() => setIsOpen(false)}
       >
         <button
-          className="px-3 sm:px-4 py-2 bg-[var(--brand-secondary)]/15 text-[var(--foreground)] rounded-lg hover:bg-[var(--brand-secondary)]/25 transition-colors text-sm border border-[var(--brand-secondary)]/20 flex items-center gap-2"
+          className="px-3 sm:px-4 py-2.5 sm:py-2 bg-[var(--brand-secondary)]/15 text-[var(--foreground)] rounded-lg hover:bg-[var(--brand-secondary)]/25 transition-colors text-sm border border-[var(--brand-secondary)]/20 flex items-center gap-2 touch-manipulation"
           aria-label="Documentation menu"
           aria-expanded={isOpen}
           onClick={() => setIsOpen(!isOpen)}
@@ -92,7 +92,7 @@ export default function DocumentationLinks({
           </svg>
         </button>
         <div
-          className={`absolute right-0 mt-2 w-64 bg-[var(--brand-background)] rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.08)] border border-[var(--brand-secondary)]/20 transition-all duration-200 z-50 ${
+          className={`fixed left-4 right-4 top-24 z-50 sm:absolute sm:left-auto sm:right-0 sm:top-auto sm:mt-2 sm:w-64 bg-[var(--brand-background)] rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.08)] border border-[var(--brand-secondary)]/20 transition-all duration-200 ${
             isOpen ? "opacity-100 visible" : "opacity-0 invisible"
           }`}
         >

--- a/ui/components/DocumentationLinks.tsx
+++ b/ui/components/DocumentationLinks.tsx
@@ -63,7 +63,7 @@ export default function DocumentationLinks({
         onMouseLeave={() => setIsOpen(false)}
       >
         <button
-          className="px-3 sm:px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors text-sm sm:text-base flex items-center gap-2"
+          className="px-3 sm:px-4 py-2 bg-[var(--brand-secondary)]/15 text-[var(--foreground)] rounded-lg hover:bg-[var(--brand-secondary)]/25 transition-colors text-sm border border-[var(--brand-secondary)]/20 flex items-center gap-2"
           aria-label="Documentation menu"
           aria-expanded={isOpen}
           onClick={() => setIsOpen(!isOpen)}
@@ -92,7 +92,7 @@ export default function DocumentationLinks({
           </svg>
         </button>
         <div
-          className={`absolute right-0 mt-2 w-64 bg-white rounded-lg shadow-lg border border-gray-200 transition-all duration-200 z-50 ${
+          className={`absolute right-0 mt-2 w-64 bg-[var(--brand-background)] rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.08)] border border-[var(--brand-secondary)]/20 transition-all duration-200 z-50 ${
             isOpen ? "opacity-100 visible" : "opacity-0 invisible"
           }`}
         >
@@ -101,20 +101,20 @@ export default function DocumentationLinks({
               <button
                 key={link.label}
                 onClick={() => onDocClick?.(link.url)}
-                className="w-full text-left block px-4 py-3 hover:bg-gray-50 transition-colors"
+                className="w-full text-left block px-4 py-3 hover:bg-[var(--brand-accent)]/10 transition-colors"
               >
                 <div className="flex items-start gap-3">
                   <span className="text-xl flex-shrink-0">{link.icon}</span>
                   <div className="flex-1 min-w-0">
-                    <div className="font-medium text-gray-900 text-sm">
-                      {link.label}
+                    <div className="font-medium text-[var(--foreground)] text-sm">
+                      {link.label} →
                     </div>
-                    <div className="text-xs text-gray-600 mt-0.5">
+                    <div className="text-xs text-[var(--brand-secondary)] mt-0.5">
                       {link.description}
                     </div>
                   </div>
                   <svg
-                    className="h-4 w-4 text-gray-400 flex-shrink-0 mt-0.5"
+                    className="h-4 w-4 text-[var(--brand-secondary)] flex-shrink-0 mt-0.5"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"
@@ -142,20 +142,20 @@ export default function DocumentationLinks({
         <button
           key={link.label}
           onClick={() => onDocClick?.(link.url)}
-          className="w-full text-left block p-3 border border-gray-200 rounded-lg hover:border-[var(--brand-primary)] hover:bg-blue-50 transition-all group"
+          className="w-full text-left block p-3 border border-[var(--brand-secondary)]/30 rounded-lg hover:border-[var(--brand-accent)] hover:bg-[var(--brand-accent)]/10 transition-all group bg-[var(--brand-background)] shadow-[0_4px_12px_rgba(0,0,0,0.08)]"
         >
           <div className="flex items-start gap-3">
             <span className="text-xl flex-shrink-0">{link.icon}</span>
             <div className="flex-1 min-w-0">
-              <div className="font-semibold text-gray-900 text-sm group-hover:text-[var(--brand-primary)] transition-colors">
-                {link.label}
+              <div className="font-semibold text-[var(--foreground)] text-sm group-hover:text-[var(--foreground)] transition-colors">
+                {link.label} →
               </div>
-              <div className="text-xs text-gray-600 mt-1">
+              <div className="text-xs text-[var(--brand-secondary)] mt-1">
                 {link.description}
               </div>
             </div>
             <svg
-              className="h-4 w-4 text-gray-400 group-hover:text-[var(--brand-primary)] flex-shrink-0 mt-0.5 transition-colors"
+              className="h-4 w-4 text-[var(--brand-secondary)] group-hover:text-[var(--brand-accent)] flex-shrink-0 mt-0.5 transition-colors"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"

--- a/ui/components/DocumentationModal.tsx
+++ b/ui/components/DocumentationModal.tsx
@@ -26,19 +26,20 @@ export default function DocumentationModal({
       aria-labelledby="documentation-title"
     >
       <div
-        className="bg-white rounded-lg shadow-xl max-w-4xl w-full mx-4 max-h-[90vh] overflow-hidden flex flex-col"
+        className="bg-[var(--brand-background)] rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.08)] max-w-4xl w-full mx-4 max-h-[90vh] overflow-hidden flex flex-col"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="p-6 border-b border-gray-200 flex items-center justify-between">
+        <div className="p-6 border-b border-[var(--brand-secondary)]/30 flex items-center justify-between">
           <h2
             id="documentation-title"
-            className="text-xl font-semibold text-gray-900"
+            className="text-xl font-normal text-[var(--foreground)]"
+            style={{ fontFamily: "var(--font-serif), serif" }}
           >
             Documentation
           </h2>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 transition-colors"
+            className="text-[var(--brand-secondary)] hover:text-[var(--foreground)] transition-colors"
             aria-label="Close"
           >
             <svg

--- a/ui/components/ExportButton.tsx
+++ b/ui/components/ExportButton.tsx
@@ -37,7 +37,7 @@ export default function ExportButton({ diff, disabled }: ExportButtonProps) {
     <button
       onClick={handleExport}
       disabled={disabled || !diff}
-      className="px-3 sm:px-4 py-2 bg-[var(--brand-secondary)]/30 text-[var(--foreground)] rounded-lg hover:bg-[var(--brand-secondary)]/40 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-sm sm:text-base border border-[var(--brand-secondary)]/40"
+      className="px-3 sm:px-4 py-2.5 sm:py-2 bg-[var(--brand-secondary)]/30 text-[var(--foreground)] rounded-lg hover:bg-[var(--brand-secondary)]/40 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-sm sm:text-base border border-[var(--brand-secondary)]/40 touch-manipulation"
     >
       <span className="hidden sm:inline">Export JSON</span>
       <span className="sm:hidden">Export</span>

--- a/ui/components/ExportButton.tsx
+++ b/ui/components/ExportButton.tsx
@@ -37,7 +37,7 @@ export default function ExportButton({ diff, disabled }: ExportButtonProps) {
     <button
       onClick={handleExport}
       disabled={disabled || !diff}
-      className="px-3 sm:px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors text-sm sm:text-base"
+      className="px-3 sm:px-4 py-2 bg-[var(--brand-secondary)]/30 text-[var(--foreground)] rounded-lg hover:bg-[var(--brand-secondary)]/40 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-sm sm:text-base border border-[var(--brand-secondary)]/40"
     >
       <span className="hidden sm:inline">Export JSON</span>
       <span className="sm:hidden">Export</span>

--- a/ui/components/FileUpload.tsx
+++ b/ui/components/FileUpload.tsx
@@ -74,7 +74,7 @@ export default function FileUpload({
 
   return (
     <div className={className}>
-      <label className="block text-sm font-medium text-gray-700 mb-2">
+      <label className="block text-sm font-medium text-[var(--foreground)] mb-2">
         {label}
       </label>
       <div
@@ -83,11 +83,11 @@ export default function FileUpload({
         onDrop={handleDrop}
         className={`
           border-2 border-dashed rounded-lg p-6 text-center cursor-pointer
-          transition-colors
+          transition-colors bg-[var(--brand-background)] shadow-[0_4px_12px_rgba(0,0,0,0.08)]
           ${
             isDragging
-              ? "border-blue-500 bg-blue-50"
-              : "border-gray-300 hover:border-gray-400"
+              ? "border-[var(--brand-accent)] bg-[var(--brand-accent)]/10"
+              : "border-[var(--brand-secondary)]/40 hover:border-[var(--brand-secondary)]/60"
           }
         `}
       >
@@ -103,7 +103,7 @@ export default function FileUpload({
           className="cursor-pointer block"
         >
           <svg
-            className="mx-auto h-12 w-12 text-gray-400"
+            className="mx-auto h-12 w-12 text-[var(--brand-secondary)]"
             stroke="currentColor"
             fill="none"
             viewBox="0 0 48 48"
@@ -115,10 +115,10 @@ export default function FileUpload({
               strokeLinejoin="round"
             />
           </svg>
-          <span className="mt-2 block text-sm text-gray-600">
-            {isDragging ? "Drop file here" : "Drag and drop or click to upload"}
+          <span className="mt-2 block text-sm text-[var(--foreground)]">
+            {isDragging ? "Drop file here" : "Drag and drop or click to upload →"}
           </span>
-          <span className="mt-1 block text-xs text-gray-500">
+          <span className="mt-1 block text-xs text-[var(--brand-secondary)]">
             {accept}
           </span>
         </label>

--- a/ui/components/GenericChangeCard.tsx
+++ b/ui/components/GenericChangeCard.tsx
@@ -53,8 +53,8 @@ function getChangeTypeStyles(changeType: GenericChangeType) {
       };
     default:
       return {
-        badge: "bg-gray-100 text-gray-800 border-gray-300",
-        bg: "bg-gray-50",
+        badge: "bg-[var(--brand-secondary)]/20 text-[var(--foreground)] border-[var(--brand-secondary)]/40",
+        bg: "bg-[var(--brand-background)]",
         icon: "•",
       };
   }
@@ -137,7 +137,7 @@ function ValueDisplay({
 
   return (
     <div className={`rounded ${className} ${className.includes('p-') ? '' : 'p-3'}`}>
-      {label && <div className="text-xs font-semibold text-gray-600 mb-1">{label}:</div>}
+      {label && <div className="text-xs font-semibold text-[var(--brand-secondary)] mb-1">{label}:</div>}
       {useDiff ? (
         // Use character-level diff highlighting
         renderDiffedText(diffChunks, diffType)
@@ -191,31 +191,31 @@ export default function GenericChangeCard({ change, index }: GenericChangeCardPr
                          change.change_type === GenericChangeType.ITEM_MOVED;
 
   return (
-    <div className={`border rounded-lg ${styles.bg} ${isExpanded ? "" : "overflow-hidden"}`}>
+    <div className={`border border-[var(--brand-secondary)]/20 rounded-lg bg-[var(--brand-background)] shadow-[0_4px_12px_rgba(0,0,0,0.08)] ${isExpanded ? "" : "overflow-hidden"}`}>
       <div
         className="px-3 sm:px-4 py-3 cursor-pointer hover:bg-opacity-80 transition-colors"
         onClick={() => setIsExpanded(!isExpanded)}
       >
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
           <div className="flex flex-wrap items-center gap-2 sm:gap-3">
-            <span className="text-sm font-medium text-gray-500">#{index + 1}</span>
+            <span className="text-sm font-medium text-[var(--brand-secondary)]">#{index + 1}</span>
             <span
               className={`px-2 py-1 text-xs font-semibold rounded border ${styles.badge}`}
             >
               {styles.icon} {formatChangeType(change.change_type)}
             </span>
-            <span className="text-sm font-mono text-gray-700 break-all">
+            <span className="text-sm font-mono text-[var(--foreground)] break-all">
               {change.path}
             </span>
           </div>
           <div className="flex items-center gap-2">
             {(change.old_line_number || change.new_line_number) && (
-              <span className="text-xs text-gray-500">
+              <span className="text-xs text-[var(--brand-secondary)]">
                 Line {change.old_line_number || change.new_line_number}
               </span>
             )}
             <svg
-              className={`w-5 h-5 text-gray-400 transition-transform ${
+              className={`w-5 h-5 text-[var(--brand-secondary)] transition-transform ${
                 isExpanded ? "rotate-180" : ""
               }`}
               fill="none"
@@ -238,15 +238,15 @@ export default function GenericChangeCard({ change, index }: GenericChangeCardPr
           {/* Key rename info */}
           {showKeyChange && change.old_key && change.new_key && (
             <div>
-              <h4 className="text-sm font-semibold text-gray-700 mb-2">Key Renamed:</h4>
+              <h4 className="text-sm font-semibold text-[var(--foreground)] mb-2">Key Renamed:</h4>
               <div className="grid grid-cols-2 gap-4">
                 <div className="bg-red-50 border border-red-200 rounded p-3">
-                  <div className="text-xs font-semibold text-gray-600 mb-1">Old Key:</div>
-                  <div className="text-sm font-mono text-gray-800">{change.old_key}</div>
+                  <div className="text-xs font-semibold text-[var(--brand-secondary)] mb-1">Old Key:</div>
+                  <div className="text-sm font-mono text-[var(--foreground)]">{change.old_key}</div>
                 </div>
                 <div className="bg-green-50 border border-green-200 rounded p-3">
-                  <div className="text-xs font-semibold text-gray-600 mb-1">New Key:</div>
-                  <div className="text-sm font-mono text-gray-800">{change.new_key}</div>
+                  <div className="text-xs font-semibold text-[var(--brand-secondary)] mb-1">New Key:</div>
+                  <div className="text-sm font-mono text-[var(--foreground)]">{change.new_key}</div>
                 </div>
               </div>
             </div>
@@ -255,15 +255,15 @@ export default function GenericChangeCard({ change, index }: GenericChangeCardPr
           {/* Path change info */}
           {showPathChange && change.old_path && change.new_path && (
             <div>
-              <h4 className="text-sm font-semibold text-gray-700 mb-2">Moved From → To:</h4>
+              <h4 className="text-sm font-semibold text-[var(--foreground)] mb-2">Moved From → To:</h4>
               <div className="grid grid-cols-2 gap-4">
                 <div className="bg-red-50 border border-red-200 rounded p-3">
-                  <div className="text-xs font-semibold text-gray-600 mb-1">Old Path:</div>
-                  <div className="text-sm font-mono text-gray-800 break-all">{change.old_path}</div>
+                  <div className="text-xs font-semibold text-[var(--brand-secondary)] mb-1">Old Path:</div>
+                  <div className="text-sm font-mono text-[var(--foreground)] break-all">{change.old_path}</div>
                 </div>
                 <div className="bg-green-50 border border-green-200 rounded p-3">
-                  <div className="text-xs font-semibold text-gray-600 mb-1">New Path:</div>
-                  <div className="text-sm font-mono text-gray-800 break-all">{change.new_path}</div>
+                  <div className="text-xs font-semibold text-[var(--brand-secondary)] mb-1">New Path:</div>
+                  <div className="text-sm font-mono text-[var(--foreground)] break-all">{change.new_path}</div>
                 </div>
               </div>
             </div>
@@ -272,14 +272,14 @@ export default function GenericChangeCard({ change, index }: GenericChangeCardPr
           {/* Value changes */}
           {(showOldValue || showNewValue) && (
             <div>
-              <h4 className="text-sm font-semibold text-gray-700 mb-2">
+              <h4 className="text-sm font-semibold text-[var(--foreground)] mb-2">
                 {change.change_type === GenericChangeType.TYPE_CHANGED ? "Type Change:" : "Value:"}
               </h4>
               {isUnchanged ? (
                 // Unchanged content: show single gray column
                 <div>
-                  <div className="bg-gray-50 border border-gray-200 rounded p-3">
-                    <div className="text-xs font-semibold text-gray-600 mb-1">Content (unchanged):</div>
+                  <div className="bg-[var(--brand-secondary)]/10 border border-[var(--brand-secondary)]/20 rounded p-3">
+                    <div className="text-xs font-semibold text-[var(--brand-secondary)] mb-1">Content (unchanged):</div>
                     <ValueDisplay
                       value={change.old_value ?? change.new_value}
                       label=""
@@ -299,8 +299,8 @@ export default function GenericChangeCard({ change, index }: GenericChangeCardPr
                       diffType="old"
                     />
                   ) : (
-                    <div className="bg-gray-100 border border-gray-200 rounded p-3">
-                      <div className="text-xs text-gray-500 italic">(not applicable)</div>
+                    <div className="bg-[var(--brand-secondary)]/15 border border-[var(--brand-secondary)]/20 rounded p-3">
+                      <div className="text-xs text-[var(--brand-secondary)] italic">(not applicable)</div>
                     </div>
                   )}
                   {showNewValue ? (
@@ -312,8 +312,8 @@ export default function GenericChangeCard({ change, index }: GenericChangeCardPr
                       diffType="new"
                     />
                   ) : (
-                    <div className="bg-gray-100 border border-gray-200 rounded p-3">
-                      <div className="text-xs text-gray-500 italic">(not applicable)</div>
+                    <div className="bg-[var(--brand-secondary)]/15 border border-[var(--brand-secondary)]/20 rounded p-3">
+                      <div className="text-xs text-[var(--brand-secondary)] italic">(not applicable)</div>
                     </div>
                   )}
                 </div>
@@ -323,7 +323,7 @@ export default function GenericChangeCard({ change, index }: GenericChangeCardPr
 
           {/* Line numbers */}
           {(change.old_line_number || change.new_line_number) && (
-            <div className="text-xs text-gray-500 flex gap-4">
+            <div className="text-xs text-[var(--brand-secondary)] flex gap-4">
               {change.old_line_number && (
                 <span>Old line: {change.old_line_number}</span>
               )}

--- a/ui/components/HelpModal.tsx
+++ b/ui/components/HelpModal.tsx
@@ -24,7 +24,7 @@ export default function HelpModal({
       aria-labelledby="help-title"
     >
       <div
-        className="bg-white rounded-lg shadow-xl max-w-3xl w-full mx-4 max-h-[90vh] overflow-y-auto"
+        className="bg-[var(--brand-background)] rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.08)] max-w-3xl w-full mx-4 max-h-[90vh] overflow-y-auto"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="p-6">
@@ -32,13 +32,14 @@ export default function HelpModal({
           <div className="flex items-center justify-between mb-6">
             <h2
               id="help-title"
-              className="text-2xl font-semibold text-gray-900"
+              className="text-2xl font-normal text-[var(--foreground)]"
+              style={{ fontFamily: "var(--font-serif), serif" }}
             >
               Help & Documentation
             </h2>
             <button
               onClick={onClose}
-              className="text-gray-400 hover:text-gray-600 transition-colors"
+              className="text-[var(--brand-secondary)] hover:text-[var(--foreground)] transition-colors"
               aria-label="Close"
             >
               <svg
@@ -58,10 +59,10 @@ export default function HelpModal({
           </div>
 
           {/* Content */}
-          <div className="space-y-6 text-gray-700">
+          <div className="space-y-6 text-[var(--brand-secondary)]">
             {/* What is yamly */}
             <section>
-              <h3 className="text-lg font-semibold text-gray-900 mb-2">
+              <h3 className="text-lg font-normal text-[var(--foreground)] mb-2" style={{ fontFamily: "var(--font-serif), serif" }}>
                 What is yamly?
               </h3>
               <p className="text-sm leading-relaxed">
@@ -71,7 +72,7 @@ export default function HelpModal({
 
             {/* How to Use */}
             <section>
-              <h3 className="text-lg font-semibold text-gray-900 mb-2">
+              <h3 className="text-lg font-normal text-[var(--foreground)] mb-2" style={{ fontFamily: "var(--font-serif), serif" }}>
                 How to Use
               </h3>
               <ol className="list-decimal list-inside space-y-2 text-sm">
@@ -101,28 +102,28 @@ export default function HelpModal({
 
             {/* Document Format */}
             <section>
-              <h3 className="text-lg font-semibold text-gray-900 mb-2">
+              <h3 className="text-lg font-normal text-[var(--foreground)] mb-2" style={{ fontFamily: "var(--font-serif), serif" }}>
                 Document Format Requirements
               </h3>
-              <div className="bg-gray-50 border border-gray-200 rounded-lg p-4 space-y-2 text-sm">
+              <div className="bg-[var(--brand-accent)]/10 border border-[var(--brand-secondary)]/20 rounded-lg p-4 space-y-2 text-sm">
                 <p>
-                  <strong>Top-level key:</strong> Documents must have{" "}
-                  <code className="bg-gray-200 px-1 rounded">document:</code> as
+                  <strong className="text-[var(--foreground)]">Top-level key:</strong> Documents must have{" "}
+                  <code className="bg-[var(--brand-secondary)]/20 px-1 rounded">document:</code> as
                   the top-level key.
                 </p>
                 <p>
-                  <strong>Section markers:</strong> All sections require a{" "}
-                  <code className="bg-gray-200 px-1 rounded">marker</code>{" "}
+                  <strong className="text-[var(--foreground)]">Section markers:</strong> All sections require a{" "}
+                  <code className="bg-[var(--brand-secondary)]/20 px-1 rounded">marker</code>{" "}
                   field, which serves as a unique identifier within the same
                   nesting level.
                 </p>
                 <p>
-                  <strong>Nesting:</strong> Supports unlimited nesting levels for
+                  <strong className="text-[var(--foreground)]">Nesting:</strong> Supports unlimited nesting levels for
                   complex document structures.
                 </p>
                 <p>
-                  <strong>Content:</strong> Each section can have a{" "}
-                  <code className="bg-gray-200 px-1 rounded">content</code>{" "}
+                  <strong className="text-[var(--foreground)]">Content:</strong> Each section can have a{" "}
+                  <code className="bg-[var(--brand-secondary)]/20 px-1 rounded">content</code>{" "}
                   field containing text for that section level.
                 </p>
               </div>
@@ -130,7 +131,7 @@ export default function HelpModal({
 
             {/* Common Use Cases */}
             <section>
-              <h3 className="text-lg font-semibold text-gray-900 mb-2">
+              <h3 className="text-lg font-normal text-[var(--foreground)] mb-2" style={{ fontFamily: "var(--font-serif), serif" }}>
                 Common Use Cases
               </h3>
               <ul className="list-disc list-inside space-y-2 text-sm">
@@ -144,25 +145,25 @@ export default function HelpModal({
 
             {/* FAQ */}
             <section>
-              <h3 className="text-lg font-semibold text-gray-900 mb-2">
+              <h3 className="text-lg font-normal text-[var(--foreground)] mb-2" style={{ fontFamily: "var(--font-serif), serif" }}>
                 Frequently Asked Questions
               </h3>
               <div className="space-y-4 text-sm">
                 <div>
-                  <h4 className="font-semibold text-gray-800 mb-1">
+                  <h4 className="font-medium text-[var(--foreground)] mb-1">
                     What file formats are supported?
                   </h4>
-                  <p className="text-gray-600">
-                    Currently, only YAML files (<code className="bg-gray-200 px-1 rounded">.yaml</code> or{" "}
-                    <code className="bg-gray-200 px-1 rounded">.yml</code>) are
+                  <p className="text-[var(--brand-secondary)]">
+                    Currently, only YAML files (<code className="bg-[var(--brand-secondary)]/20 px-1 rounded">.yaml</code> or{" "}
+                    <code className="bg-[var(--brand-secondary)]/20 px-1 rounded">.yml</code>) are
                     supported.
                   </p>
                 </div>
                 <div>
-                  <h4 className="font-semibold text-gray-800 mb-1">
+                  <h4 className="font-medium text-[var(--foreground)] mb-1">
                     What do the different change types mean?
                   </h4>
-                  <ul className="list-disc list-inside space-y-1 text-gray-600 ml-2">
+                  <ul className="list-disc list-inside space-y-1 text-[var(--brand-secondary)] ml-2">
                     <li>
                       <strong>SECTION_ADDED:</strong> A new section was added in
                       the new version
@@ -186,21 +187,21 @@ export default function HelpModal({
                   </ul>
                 </div>
                 <div>
-                  <h4 className="font-semibold text-gray-800 mb-1">
+                  <h4 className="font-medium text-[var(--foreground)] mb-1">
                     How do I handle validation errors?
                   </h4>
-                  <p className="text-gray-600">
-                    Ensure your YAML has <code className="bg-gray-200 px-1 rounded">document:</code> as the
-                    top-level key and all sections have <code className="bg-gray-200 px-1 rounded">marker</code> fields.
+                  <p className="text-[var(--brand-secondary)]">
+                    Ensure your YAML has <code className="bg-[var(--brand-secondary)]/20 px-1 rounded">document:</code> as the
+                    top-level key and all sections have <code className="bg-[var(--brand-secondary)]/20 px-1 rounded">marker</code> fields.
                     Check the error message for specific details about what's
                     missing.
                   </p>
                 </div>
                 <div>
-                  <h4 className="font-semibold text-gray-800 mb-1">
+                  <h4 className="font-medium text-[var(--foreground)] mb-1">
                     Can I use this with Hebrew content?
                   </h4>
-                  <p className="text-gray-600">
+                  <p className="text-[var(--brand-secondary)]">
                     Yes! yamly fully supports Hebrew content and RTL
                     (right-to-left) text. The tool was designed with Hebrew
                     legal documents in mind.
@@ -211,10 +212,10 @@ export default function HelpModal({
 
             {/* Documentation Links */}
             <section>
-              <h3 className="text-lg font-semibold text-gray-900 mb-3">
+              <h3 className="text-lg font-normal text-[var(--foreground)] mb-3" style={{ fontFamily: "var(--font-serif), serif" }}>
                 Learn More
               </h3>
-              <p className="text-sm text-gray-600 mb-3">
+              <p className="text-sm text-[var(--brand-secondary)] mb-3">
                 Explore additional ways to use yamly:
               </p>
               <DocumentationLinks variant="list" onDocClick={onDocClick} />
@@ -225,9 +226,9 @@ export default function HelpModal({
           <div className="mt-6 flex justify-end">
             <button
               onClick={onClose}
-              className="px-4 py-2 bg-[var(--brand-primary)] text-white rounded-lg hover:opacity-90 transition-opacity text-sm font-medium"
+              className="px-6 py-2 bg-[var(--brand-cta-bg)] text-[var(--brand-cta-text)] rounded-lg hover:opacity-90 transition-opacity text-sm font-medium uppercase"
             >
-              Close
+              Close →
             </button>
           </div>
         </div>

--- a/ui/components/InlineDiscussion.tsx
+++ b/ui/components/InlineDiscussion.tsx
@@ -32,7 +32,7 @@ function getChangeTypeStyles(changeType: ChangeType) {
     case ChangeType.SECTION_MOVED:
       return "bg-purple-100 text-purple-800 border-purple-300";
     default:
-      return "bg-gray-100 text-gray-800 border-gray-300";
+      return "bg-[var(--brand-secondary)]/20 text-[var(--foreground)] border-[var(--brand-secondary)]/40";
   }
 }
 
@@ -80,9 +80,9 @@ export default function InlineDiscussion({ change, lineNumber, side }: InlineDis
     (change.old_content !== null && change.new_content === null);
 
   return (
-    <div className="bg-white border border-gray-300 rounded-lg shadow-sm p-3 w-80 max-w-full">
+    <div className="bg-[var(--brand-background)] border border-[var(--brand-secondary)]/40 rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.08)] p-3 w-80 max-w-full">
       {/* Header */}
-      <div className="mb-3 pb-2 border-b border-gray-200">
+      <div className="mb-3 pb-2 border-b border-[var(--brand-secondary)]/30">
         <div className="flex items-center gap-2 mb-2">
           <span
             className={`px-2 py-1 text-xs font-semibold rounded border ${getChangeTypeStyles(
@@ -94,8 +94,8 @@ export default function InlineDiscussion({ change, lineNumber, side }: InlineDis
         </div>
         <div className="text-xs space-y-1">
           <div>
-            <span className="font-medium text-gray-700">Marker:</span>{" "}
-            <span className="font-mono text-gray-900">{change.marker}</span>
+            <span className="font-medium text-[var(--foreground)]">Marker:</span>{" "}
+            <span className="font-mono text-[var(--foreground)]">{change.marker}</span>
           </div>
           {hasPathChange && change.change_type === ChangeType.SECTION_MOVED && (
             <div className="flex items-center gap-2 text-xs text-purple-700 bg-purple-50 px-2 py-1 rounded border border-purple-200 mt-2">
@@ -134,31 +134,31 @@ export default function InlineDiscussion({ change, lineNumber, side }: InlineDis
 
       {/* Change details */}
       {(hasTitleChange || hasContentChange) && (
-        <div className="mb-3 pb-2 border-b border-gray-200 space-y-2">
+        <div className="mb-3 pb-2 border-b border-[var(--brand-secondary)]/30 space-y-2">
           {hasTitleChange && (
             <div>
-              <h5 className="text-xs font-semibold text-gray-700 mb-1">Title Change:</h5>
+              <h5 className="text-xs font-semibold text-[var(--foreground)] mb-1">Title Change:</h5>
               <div className="grid grid-cols-2 gap-2 text-xs">
                 <div className="bg-red-50 border border-red-200 rounded p-2">
-                  <div className="font-mono text-gray-800">{change.old_title || "(empty)"}</div>
+                  <div className="font-mono text-[var(--foreground)]">{change.old_title || "(empty)"}</div>
                 </div>
                 <div className="bg-green-50 border border-green-200 rounded p-2">
-                  <div className="font-mono text-gray-800">{change.new_title || "(empty)"}</div>
+                  <div className="font-mono text-[var(--foreground)]">{change.new_title || "(empty)"}</div>
                 </div>
               </div>
             </div>
           )}
           {hasContentChange && (
             <div>
-              <h5 className="text-xs font-semibold text-gray-700 mb-1">Content Change:</h5>
+              <h5 className="text-xs font-semibold text-[var(--foreground)] mb-1">Content Change:</h5>
               <div className="grid grid-cols-2 gap-2 text-xs max-h-32 overflow-y-auto">
                 <div className="bg-red-50 border border-red-200 rounded p-2">
-                  <pre className="whitespace-pre-wrap font-mono text-gray-800 text-xs">
+                  <pre className="whitespace-pre-wrap font-mono text-[var(--foreground)] text-xs">
                     {change.old_content || "(empty)"}
                   </pre>
                 </div>
                 <div className="bg-green-50 border border-green-200 rounded p-2">
-                  <pre className="whitespace-pre-wrap font-mono text-gray-800 text-xs">
+                  <pre className="whitespace-pre-wrap font-mono text-[var(--foreground)] text-xs">
                     {change.new_content || "(empty)"}
                   </pre>
                 </div>
@@ -170,7 +170,7 @@ export default function InlineDiscussion({ change, lineNumber, side }: InlineDis
 
       {/* Discussion */}
       <div className="space-y-2">
-        <h5 className="text-xs font-semibold text-gray-700">Discussion</h5>
+        <h5 className="text-xs font-semibold text-[var(--foreground)]">Discussion</h5>
         <textarea
           value={commentText}
           onChange={(e) => setCommentText(e.target.value)}
@@ -179,14 +179,14 @@ export default function InlineDiscussion({ change, lineNumber, side }: InlineDis
               handleAddComment();
             }
           }}
-          className="w-full p-2 border border-gray-300 rounded resize-none text-xs"
+          className="w-full p-2 border border-[var(--brand-secondary)]/40 rounded resize-none text-xs bg-[var(--brand-background)]"
           rows={3}
           placeholder="Add a comment... (Cmd/Ctrl+Enter to submit)"
         />
         <button
           onClick={handleAddComment}
           disabled={!commentText.trim()}
-          className="px-3 py-1 bg-blue-600 text-white rounded text-xs hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed"
+          className="px-3 py-1 bg-[var(--brand-cta-bg)] text-[var(--brand-cta-text)] rounded text-xs hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
         >
           Comment
         </button>

--- a/ui/components/MermaidDiagram.tsx
+++ b/ui/components/MermaidDiagram.tsx
@@ -106,7 +106,7 @@ export default function MermaidDiagram({ code }: MermaidDiagramProps) {
     const handleTab = (e: KeyboardEvent) => {
       if (e.key !== "Tab") return;
 
-      const modal = expandedRef.current?.closest(".bg-white");
+      const modal = expandedRef.current?.closest("[data-mermaid-modal]");
       if (!modal) return;
 
       const focusableElements = modal.querySelectorAll<HTMLElement>(
@@ -138,7 +138,7 @@ export default function MermaidDiagram({ code }: MermaidDiagramProps) {
 
     // Focus first interactive element in modal
     setTimeout(() => {
-      const modal = expandedRef.current?.closest(".bg-white");
+      const modal = expandedRef.current?.closest("[data-mermaid-modal]");
       const firstButton = modal?.querySelector<HTMLElement>("button");
       firstButton?.focus();
     }, 0);
@@ -180,7 +180,7 @@ export default function MermaidDiagram({ code }: MermaidDiagramProps) {
         <div className="absolute top-2 right-2 z-10 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
           <button
             onClick={handleInlineZoomOut}
-            className="px-2 py-1 bg-gray-800 text-white border border-gray-700 rounded text-xs hover:bg-gray-700 shadow-lg font-medium"
+            className="px-2 py-1 bg-[var(--brand-cta-bg)] text-[var(--brand-cta-text)] border border-[var(--foreground)]/30 rounded text-xs hover:opacity-90 shadow-lg font-medium"
             title="Zoom out"
             aria-label="Zoom out"
           >
@@ -188,7 +188,7 @@ export default function MermaidDiagram({ code }: MermaidDiagramProps) {
           </button>
           <button
             onClick={handleInlineResetZoom}
-            className="px-2 py-1 bg-gray-800 text-white border border-gray-700 rounded text-xs hover:bg-gray-700 shadow-lg font-medium"
+            className="px-2 py-1 bg-[var(--brand-cta-bg)] text-[var(--brand-cta-text)] border border-[var(--foreground)]/30 rounded text-xs hover:opacity-90 shadow-lg font-medium"
             title="Reset zoom"
             aria-label="Reset zoom"
           >
@@ -196,7 +196,7 @@ export default function MermaidDiagram({ code }: MermaidDiagramProps) {
           </button>
           <button
             onClick={handleInlineZoomIn}
-            className="px-2 py-1 bg-gray-800 text-white border border-gray-700 rounded text-xs hover:bg-gray-700 shadow-lg font-medium"
+            className="px-2 py-1 bg-[var(--brand-cta-bg)] text-[var(--brand-cta-text)] border border-[var(--foreground)]/30 rounded text-xs hover:opacity-90 shadow-lg font-medium"
             title="Zoom in"
             aria-label="Zoom in"
           >
@@ -205,7 +205,7 @@ export default function MermaidDiagram({ code }: MermaidDiagramProps) {
           <button
             ref={expandButtonRef}
             onClick={() => setIsExpanded(true)}
-            className="px-2 py-1 bg-gray-800 text-white border border-gray-700 rounded text-xs hover:bg-gray-700 shadow-lg font-medium"
+            className="px-2 py-1 bg-[var(--brand-cta-bg)] text-[var(--brand-cta-text)] border border-[var(--foreground)]/30 rounded text-xs hover:opacity-90 shadow-lg font-medium"
             title="Expand to full screen"
             aria-label="Expand diagram"
           >
@@ -214,7 +214,7 @@ export default function MermaidDiagram({ code }: MermaidDiagramProps) {
         </div>
 
         {/* Diagram container with zoom */}
-        <div className="flex justify-center overflow-x-auto overflow-y-auto max-h-[600px] bg-gray-50 rounded-lg p-4">
+        <div className="flex justify-center overflow-x-auto overflow-y-auto max-h-[600px] bg-[var(--brand-background)] rounded-lg p-4 shadow-[0_4px_12px_rgba(0,0,0,0.08)]">
           <div
             ref={diagramRef}
             className="mermaid-diagram"
@@ -238,17 +238,18 @@ export default function MermaidDiagram({ code }: MermaidDiagramProps) {
           aria-label="Expanded diagram"
         >
           <div
-            className="bg-white rounded-lg shadow-xl max-w-[95vw] max-h-[95vh] w-full mx-4 flex flex-col"
+            data-mermaid-modal
+            className="bg-[var(--brand-background)] rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.08)] max-w-[95vw] max-h-[95vh] w-full mx-4 flex flex-col"
             onClick={(e) => e.stopPropagation()}
           >
-            <div className="p-4 border-b border-gray-200 flex items-center justify-between">
-              <h3 className="text-lg font-semibold text-gray-900">
+            <div className="p-4 border-b border-[var(--brand-secondary)]/30 flex items-center justify-between">
+              <h3 className="text-lg font-normal text-[var(--foreground)]" style={{ fontFamily: "var(--font-serif), serif" }}>
                 Diagram (Click outside to close)
               </h3>
               <div className="flex gap-2 items-center">
                 <button
                   onClick={handleExpandedZoomOut}
-                  className="px-3 py-1 bg-gray-100 border border-gray-300 rounded text-sm hover:bg-gray-200"
+                  className="px-3 py-1 bg-[var(--brand-secondary)]/15 border border-[var(--brand-secondary)]/40 rounded text-sm hover:bg-[var(--brand-accent)]/10"
                   title="Zoom out"
                   aria-label="Zoom out"
                 >
@@ -256,7 +257,7 @@ export default function MermaidDiagram({ code }: MermaidDiagramProps) {
                 </button>
                 <button
                   onClick={handleExpandedResetZoom}
-                  className="px-3 py-1 bg-gray-100 border border-gray-300 rounded text-sm hover:bg-gray-200"
+                  className="px-3 py-1 bg-[var(--brand-secondary)]/15 border border-[var(--brand-secondary)]/40 rounded text-sm hover:bg-[var(--brand-accent)]/10"
                   title="Reset zoom"
                   aria-label="Reset zoom"
                 >
@@ -264,7 +265,7 @@ export default function MermaidDiagram({ code }: MermaidDiagramProps) {
                 </button>
                 <button
                   onClick={handleExpandedZoomIn}
-                  className="px-3 py-1 bg-gray-100 border border-gray-300 rounded text-sm hover:bg-gray-200"
+                  className="px-3 py-1 bg-[var(--brand-secondary)]/15 border border-[var(--brand-secondary)]/40 rounded text-sm hover:bg-[var(--brand-accent)]/10"
                   title="Zoom in"
                   aria-label="Zoom in"
                 >
@@ -272,7 +273,7 @@ export default function MermaidDiagram({ code }: MermaidDiagramProps) {
                 </button>
                 <button
                   onClick={() => setIsExpanded(false)}
-                  className="ml-2 text-gray-400 hover:text-gray-600 transition-colors"
+                  className="ml-2 text-[var(--brand-secondary)] hover:text-[var(--foreground)] transition-colors"
                   aria-label="Close"
                 >
                   <svg
@@ -291,7 +292,7 @@ export default function MermaidDiagram({ code }: MermaidDiagramProps) {
                 </button>
               </div>
             </div>
-            <div className="flex-1 overflow-auto p-8 bg-gray-50">
+            <div className="flex-1 overflow-auto p-8 bg-[var(--brand-accent)]/5">
               <div
                 ref={expandedRef}
                 className="mermaid-diagram flex justify-center"

--- a/ui/components/ModeSelector.tsx
+++ b/ui/components/ModeSelector.tsx
@@ -22,15 +22,15 @@ export default function ModeSelector({
   const [showSchema, setShowSchema] = useState(false);
 
   return (
-    <div className="space-y-4 border-b border-gray-200 pb-4">
+    <div className="space-y-4 border-b border-[var(--brand-secondary)]/30 pb-4">
       <div>
         <div className="flex items-center justify-between mb-2">
           <div className="flex items-center gap-2">
-            <label className="block text-sm font-medium text-gray-700">
+            <label className="block text-sm font-medium text-[var(--foreground)]">
               Diff Mode
             </label>
             {disabled && (
-              <span className="text-xs text-gray-500 flex items-center gap-1">
+              <span className="text-xs text-[var(--brand-secondary)] flex items-center gap-1">
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
                 </svg>
@@ -42,7 +42,7 @@ export default function ModeSelector({
             <button
               type="button"
               onClick={() => setShowSchema(true)}
-              className="text-xs text-[var(--brand-primary)] hover:underline flex items-center gap-1"
+              className="text-xs text-[var(--brand-accent)] hover:underline flex items-center gap-1"
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
@@ -58,8 +58,8 @@ export default function ModeSelector({
             disabled={disabled}
             className={`flex-1 px-3 py-2 text-sm font-medium rounded-lg border transition-colors ${
               mode === "general"
-                ? "bg-[var(--brand-primary)] text-white border-[var(--brand-primary)]"
-                : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+                ? "bg-[var(--brand-cta-bg)] text-[var(--brand-cta-text)] border-[var(--brand-cta-bg)]"
+                : "bg-[var(--brand-background)] text-[var(--foreground)] border-[var(--brand-secondary)]/40 hover:bg-[var(--brand-accent)]/10"
             } ${disabled ? "opacity-50 cursor-not-allowed" : ""}`}
           >
             General YAML
@@ -70,8 +70,8 @@ export default function ModeSelector({
             disabled={disabled}
             className={`flex-1 px-3 py-2 text-sm font-medium rounded-lg border transition-colors ${
               mode === "legal_document"
-                ? "bg-[var(--brand-primary)] text-white border-[var(--brand-primary)]"
-                : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+                ? "bg-[var(--brand-cta-bg)] text-[var(--brand-cta-text)] border-[var(--brand-cta-bg)]"
+                : "bg-[var(--brand-background)] text-[var(--foreground)] border-[var(--brand-secondary)]/40 hover:bg-[var(--brand-accent)]/10"
             } ${disabled ? "opacity-50 cursor-not-allowed" : ""}`}
           >
             Legal Document
@@ -82,14 +82,14 @@ export default function ModeSelector({
             disabled={disabled}
             className={`flex-1 px-3 py-2 text-sm font-medium rounded-lg border transition-colors ${
               mode === "auto"
-                ? "bg-[var(--brand-primary)] text-white border-[var(--brand-primary)]"
-                : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50"
+                ? "bg-[var(--brand-cta-bg)] text-[var(--brand-cta-text)] border-[var(--brand-cta-bg)]"
+                : "bg-[var(--brand-background)] text-[var(--foreground)] border-[var(--brand-secondary)]/40 hover:bg-[var(--brand-accent)]/10"
             } ${disabled ? "opacity-50 cursor-not-allowed" : ""}`}
           >
             Auto-detect
           </button>
         </div>
-        <p className="mt-2 text-xs text-gray-500">
+        <p className="mt-2 text-xs text-[var(--brand-secondary)]">
           {mode === "auto" &&
             "Automatically detects if YAML follows legal document structure (document → sections → marker)"}
           {mode === "general" &&
@@ -139,10 +139,10 @@ function IdentityRulesEditor({
 
   return (
     <div>
-      <label className="block text-sm font-medium text-gray-700 mb-2">
+      <label className="block text-sm font-medium text-[var(--foreground)] mb-2">
         Identity Fields (optional)
       </label>
-      <p className="text-xs text-gray-500 mb-3">
+      <p className="text-xs text-[var(--brand-secondary)] mb-3">
         Specify which field identifies items in each array type. Leave empty for
         auto-detection.
       </p>
@@ -151,13 +151,13 @@ function IdentityRulesEditor({
         <button
           type="button"
           onClick={addRule}
-          className="w-full px-4 py-2 border-2 border-dashed border-gray-300 rounded-lg text-gray-600 hover:border-gray-400 hover:text-gray-700 transition-colors"
+          className="w-full px-4 py-2 border-2 border-dashed border-[var(--brand-secondary)]/40 rounded-lg text-[var(--brand-secondary)] hover:border-[var(--brand-accent)] hover:text-[var(--foreground)] transition-colors"
         >
           + Add identity rule
         </button>
       ) : (
         <div className="space-y-2">
-          <div className="grid grid-cols-12 gap-2 text-xs font-medium text-gray-600 mb-2">
+          <div className="grid grid-cols-12 gap-2 text-xs font-medium text-[var(--brand-secondary)] mb-2">
             <div className="col-span-3">Array Name</div>
             <div className="col-span-2">When Field</div>
             <div className="col-span-2">Equals Value</div>
@@ -171,7 +171,7 @@ function IdentityRulesEditor({
                 value={rule.array}
                 onChange={(e) => updateRule(index, "array", e.target.value)}
                 placeholder="e.g., containers"
-                className="col-span-3 px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-[var(--brand-primary)] focus:border-transparent"
+                className="col-span-3 px-2 py-1.5 text-sm border border-[var(--brand-secondary)]/40 rounded focus:ring-1 focus:ring-[var(--brand-accent)] focus:border-transparent bg-[var(--brand-background)]"
               />
               <input
                 type="text"
@@ -180,7 +180,7 @@ function IdentityRulesEditor({
                   updateRule(index, "when_field", e.target.value || null)
                 }
                 placeholder="e.g., type"
-                className="col-span-2 px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-[var(--brand-primary)] focus:border-transparent"
+                className="col-span-2 px-2 py-1.5 text-sm border border-[var(--brand-secondary)]/40 rounded focus:ring-1 focus:ring-[var(--brand-accent)] focus:border-transparent bg-[var(--brand-background)]"
               />
               <input
                 type="text"
@@ -190,7 +190,7 @@ function IdentityRulesEditor({
                 }
                 placeholder="e.g., book"
                 disabled={!rule.when_field}
-                className="col-span-2 px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-[var(--brand-primary)] focus:border-transparent disabled:bg-gray-100 disabled:text-gray-400"
+                className="col-span-2 px-2 py-1.5 text-sm border border-[var(--brand-secondary)]/40 rounded focus:ring-1 focus:ring-[var(--brand-accent)] focus:border-transparent disabled:opacity-50 bg-[var(--brand-background)]"
               />
               <input
                 type="text"
@@ -199,7 +199,7 @@ function IdentityRulesEditor({
                   updateRule(index, "identity_field", e.target.value)
                 }
                 placeholder="e.g., name"
-                className="col-span-3 px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-[var(--brand-primary)] focus:border-transparent"
+                className="col-span-3 px-2 py-1.5 text-sm border border-[var(--brand-secondary)]/40 rounded focus:ring-1 focus:ring-[var(--brand-accent)] focus:border-transparent bg-[var(--brand-background)]"
               />
               <button
                 type="button"
@@ -213,7 +213,7 @@ function IdentityRulesEditor({
           <button
             type="button"
             onClick={addRule}
-            className="w-full px-3 py-1.5 text-sm border border-gray-300 rounded-lg text-gray-600 hover:bg-gray-50 transition-colors"
+            className="w-full px-3 py-1.5 text-sm border border-[var(--brand-secondary)]/40 rounded-lg text-[var(--brand-secondary)] hover:bg-[var(--brand-accent)]/10 transition-colors bg-[var(--brand-background)]"
           >
             + Add rule
           </button>

--- a/ui/components/OnboardingModal.tsx
+++ b/ui/components/OnboardingModal.tsx
@@ -65,7 +65,7 @@ export default function OnboardingModal({
       aria-labelledby="onboarding-title"
     >
       <div
-        className={`bg-[var(--brand-background)] rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.08)] max-w-2xl w-full mx-4 max-h-[90vh] overflow-y-auto transform transition-all ${
+        className={`bg-[var(--background)] rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.08)] max-w-2xl w-full mx-4 max-h-[90vh] overflow-y-auto transform transition-all ${
           isClosing ? "scale-95 opacity-0" : "scale-100 opacity-100"
         }`}
         onClick={(e) => e.stopPropagation()}
@@ -75,8 +75,7 @@ export default function OnboardingModal({
           <div className="flex items-center justify-between mb-4">
             <h2
               id="onboarding-title"
-              className="text-2xl font-normal text-[var(--foreground)]"
-              style={{ fontFamily: "var(--font-serif), serif" }}
+              className="text-2xl font-serif font-normal text-[var(--foreground)]"
             >
               Welcome to yamly
             </h2>
@@ -108,8 +107,8 @@ export default function OnboardingModal({
               updates in legal docs, configuration files, and more.
             </p>
 
-            <div className="bg-[var(--brand-accent)]/10 border border-[var(--brand-accent)]/40 rounded-lg p-4">
-              <h3 className="font-medium text-[var(--foreground)] mb-2" style={{ fontFamily: "var(--font-serif), serif" }}>
+            <div className="bg-[var(--brand-background)] border border-[var(--brand-secondary)]/20 rounded-lg p-4 shadow-[0_4px_12px_rgba(0,0,0,0.08)]">
+              <h3 className="font-serif font-medium text-[var(--foreground)] mb-2">
                 Try Example Documents
               </h3>
               <p className="text-sm text-[var(--brand-secondary)]">
@@ -119,7 +118,7 @@ export default function OnboardingModal({
             </div>
 
             <div>
-              <h3 className="font-medium text-[var(--foreground)] mb-2" style={{ fontFamily: "var(--font-serif), serif" }}>
+              <h3 className="font-serif font-medium text-[var(--foreground)] mb-2">
                 Key Features:
               </h3>
               <ul className="space-y-2 text-sm">
@@ -185,7 +184,7 @@ export default function OnboardingModal({
             </div>
 
             <div>
-              <h3 className="font-medium text-[var(--foreground)] mb-2" style={{ fontFamily: "var(--font-serif), serif" }}>
+              <h3 className="font-serif font-medium text-[var(--foreground)] mb-2">
                 Coming Soon
               </h3>
               <ul className="space-y-2 text-sm">
@@ -268,7 +267,7 @@ export default function OnboardingModal({
               </ul>
             </div>
 
-            <div className="bg-[var(--brand-accent)]/10 border border-[var(--brand-secondary)]/20 rounded-lg p-4">
+            <div className="bg-[var(--brand-background)] border border-[var(--brand-secondary)]/20 rounded-lg p-4 shadow-[0_4px_12px_rgba(0,0,0,0.08)]">
               <p className="text-sm text-[var(--brand-secondary)]">
                 <strong className="text-[var(--foreground)]">Get started:</strong> Load two YAML documents and click{" "}
                 <strong>Run diff →</strong> to see the changes.

--- a/ui/components/OnboardingModal.tsx
+++ b/ui/components/OnboardingModal.tsx
@@ -81,7 +81,7 @@ export default function OnboardingModal({
             </h2>
             <button
               onClick={handleClose}
-              className="text-[var(--brand-secondary)] hover:text-[var(--foreground)] transition-colors"
+              className="p-2 -m-2 sm:p-0 sm:m-0 text-[var(--brand-secondary)] hover:text-[var(--foreground)] transition-colors touch-manipulation rounded-lg hover:bg-[var(--brand-secondary)]/10 active:bg-[var(--brand-secondary)]/20"
               aria-label="Close"
             >
               <svg

--- a/ui/components/OnboardingModal.tsx
+++ b/ui/components/OnboardingModal.tsx
@@ -65,7 +65,7 @@ export default function OnboardingModal({
       aria-labelledby="onboarding-title"
     >
       <div
-        className={`bg-white rounded-lg shadow-xl max-w-2xl w-full mx-4 max-h-[90vh] overflow-y-auto transform transition-all ${
+        className={`bg-[var(--brand-background)] rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.08)] max-w-2xl w-full mx-4 max-h-[90vh] overflow-y-auto transform transition-all ${
           isClosing ? "scale-95 opacity-0" : "scale-100 opacity-100"
         }`}
         onClick={(e) => e.stopPropagation()}
@@ -75,13 +75,14 @@ export default function OnboardingModal({
           <div className="flex items-center justify-between mb-4">
             <h2
               id="onboarding-title"
-              className="text-2xl font-semibold text-gray-900"
+              className="text-2xl font-normal text-[var(--foreground)]"
+              style={{ fontFamily: "var(--font-serif), serif" }}
             >
               Welcome to yamly
             </h2>
             <button
               onClick={handleClose}
-              className="text-gray-400 hover:text-gray-600 transition-colors"
+              className="text-[var(--brand-secondary)] hover:text-[var(--foreground)] transition-colors"
               aria-label="Close"
             >
               <svg
@@ -101,30 +102,30 @@ export default function OnboardingModal({
           </div>
 
           {/* Content */}
-          <div className="space-y-4 text-gray-700">
+          <div className="space-y-4 text-[var(--brand-secondary)]">
             <p className="text-base leading-relaxed">
               Compare and review changes in YAML documents. Ideal for tracking
               updates in legal docs, configuration files, and more.
             </p>
 
-            <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-              <h3 className="font-semibold text-blue-900 mb-2">
+            <div className="bg-[var(--brand-accent)]/10 border border-[var(--brand-accent)]/40 rounded-lg p-4">
+              <h3 className="font-medium text-[var(--foreground)] mb-2" style={{ fontFamily: "var(--font-serif), serif" }}>
                 Try Example Documents
               </h3>
-              <p className="text-sm text-blue-800">
+              <p className="text-sm text-[var(--brand-secondary)]">
                 Scroll up to explore sample documents that show how diffing
                 works. Click any example to load it into the editors.
               </p>
             </div>
 
             <div>
-              <h3 className="font-semibold text-gray-900 mb-2">
+              <h3 className="font-medium text-[var(--foreground)] mb-2" style={{ fontFamily: "var(--font-serif), serif" }}>
                 Key Features:
               </h3>
               <ul className="space-y-2 text-sm">
                 <li className="flex items-start gap-2">
                   <svg
-                    className="h-5 w-5 text-[var(--brand-primary)] mt-0.5 flex-shrink-0"
+                    className="h-5 w-5 text-[var(--brand-accent)] mt-0.5 flex-shrink-0"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"
@@ -143,7 +144,7 @@ export default function OnboardingModal({
                 </li>
                 <li className="flex items-start gap-2">
                   <svg
-                    className="h-5 w-5 text-[var(--brand-primary)] mt-0.5 flex-shrink-0"
+                    className="h-5 w-5 text-[var(--brand-accent)] mt-0.5 flex-shrink-0"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"
@@ -162,7 +163,7 @@ export default function OnboardingModal({
                 </li>
                 <li className="flex items-start gap-2">
                   <svg
-                    className="h-5 w-5 text-[var(--brand-primary)] mt-0.5 flex-shrink-0"
+                    className="h-5 w-5 text-[var(--brand-accent)] mt-0.5 flex-shrink-0"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"
@@ -184,13 +185,13 @@ export default function OnboardingModal({
             </div>
 
             <div>
-              <h3 className="font-semibold text-gray-900 mb-2">
+              <h3 className="font-medium text-[var(--foreground)] mb-2" style={{ fontFamily: "var(--font-serif), serif" }}>
                 Coming Soon
               </h3>
               <ul className="space-y-2 text-sm">
                 <li className="flex items-start gap-2">
                   <svg
-                    className="h-5 w-5 text-[var(--brand-primary)] mt-0.5 flex-shrink-0"
+                    className="h-5 w-5 text-[var(--brand-accent)] mt-0.5 flex-shrink-0"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"
@@ -209,7 +210,7 @@ export default function OnboardingModal({
                 </li>
                 <li className="flex items-start gap-2">
                   <svg
-                    className="h-5 w-5 text-[var(--brand-primary)] mt-0.5 flex-shrink-0"
+                    className="h-5 w-5 text-[var(--brand-accent)] mt-0.5 flex-shrink-0"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"
@@ -228,7 +229,7 @@ export default function OnboardingModal({
                 </li>
                 <li className="flex items-start gap-2">
                   <svg
-                    className="h-5 w-5 text-[var(--brand-primary)] mt-0.5 flex-shrink-0"
+                    className="h-5 w-5 text-[var(--brand-accent)] mt-0.5 flex-shrink-0"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"
@@ -247,7 +248,7 @@ export default function OnboardingModal({
                 </li>
                 <li className="flex items-start gap-2">
                   <svg
-                    className="h-5 w-5 text-[var(--brand-primary)] mt-0.5 flex-shrink-0"
+                    className="h-5 w-5 text-[var(--brand-accent)] mt-0.5 flex-shrink-0"
                     fill="none"
                     viewBox="0 0 24 24"
                     stroke="currentColor"
@@ -267,10 +268,10 @@ export default function OnboardingModal({
               </ul>
             </div>
 
-            <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
-              <p className="text-sm text-gray-700">
-                <strong>Get started:</strong> Load two YAML documents and click{" "}
-                <strong>Run Diff</strong> to see the changes.
+            <div className="bg-[var(--brand-accent)]/10 border border-[var(--brand-secondary)]/20 rounded-lg p-4">
+              <p className="text-sm text-[var(--brand-secondary)]">
+                <strong className="text-[var(--foreground)]">Get started:</strong> Load two YAML documents and click{" "}
+                <strong>Run diff →</strong> to see the changes.
               </p>
             </div>
           </div>
@@ -279,15 +280,15 @@ export default function OnboardingModal({
           <div className="mt-6 flex flex-col sm:flex-row gap-3 justify-end">
             <button
               onClick={handleDontShowAgain}
-              className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 transition-colors"
+              className="px-4 py-2 text-sm text-[var(--brand-secondary)] hover:text-[var(--foreground)] transition-colors"
             >
               Don't show again
             </button>
             <button
               onClick={handleClose}
-              className="px-4 py-2 bg-[var(--brand-primary)] text-white rounded-lg hover:opacity-90 transition-opacity text-sm font-medium"
+              className="px-6 py-2 bg-[var(--brand-cta-bg)] text-[var(--brand-cta-text)] rounded-lg hover:opacity-90 transition-opacity text-sm font-medium uppercase"
             >
-              Get Started
+              Get Started →
             </button>
           </div>
         </div>

--- a/ui/components/SchemaViewer.tsx
+++ b/ui/components/SchemaViewer.tsx
@@ -42,18 +42,18 @@ export default function SchemaViewer({ isOpen, onClose }: SchemaViewerProps) {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50">
-      <div className="bg-white rounded-xl shadow-2xl max-w-4xl w-full max-h-[90vh] flex flex-col">
+      <div className="bg-[var(--brand-background)] rounded-xl shadow-[0_4px_12px_rgba(0,0,0,0.08)] max-w-4xl w-full max-h-[90vh] flex flex-col">
         {/* Header */}
-        <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
+        <div className="px-6 py-4 border-b border-[var(--brand-secondary)]/30 flex items-center justify-between">
           <div>
-            <h2 className="text-xl font-semibold text-gray-900">Legal Document Schema</h2>
-            <p className="text-sm text-gray-600 mt-1">
+            <h2 className="text-xl font-normal text-[var(--foreground)]" style={{ fontFamily: "var(--font-serif), serif" }}>Legal Document Schema</h2>
+            <p className="text-sm text-[var(--brand-secondary)] mt-1">
               OpenSpec schema for legal documents with marker-based diffing
             </p>
           </div>
           <button
             onClick={onClose}
-            className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-lg transition-colors"
+            className="p-2 text-[var(--brand-secondary)] hover:text-[var(--foreground)] hover:bg-[var(--brand-accent)]/10 rounded-lg transition-colors"
           >
             <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -67,13 +67,13 @@ export default function SchemaViewer({ isOpen, onClose }: SchemaViewerProps) {
             <button
               onClick={handleCopy}
               disabled={!schema || loading}
-              className="absolute top-3 right-3 px-3 py-1.5 text-xs font-medium text-gray-300 bg-gray-700 hover:bg-gray-600 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="absolute top-3 right-3 px-3 py-1.5 text-xs font-medium text-[var(--brand-cta-text)] bg-[var(--brand-cta-bg)] hover:opacity-90 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {copied ? "Copied!" : "Copy"}
             </button>
             {loading && (
               <div className="flex items-center justify-center py-12">
-                <div className="text-gray-400 text-sm">Loading schema...</div>
+                <div className="text-[var(--brand-secondary)] text-sm">Loading schema...</div>
               </div>
             )}
             {error && (
@@ -90,15 +90,15 @@ export default function SchemaViewer({ isOpen, onClose }: SchemaViewerProps) {
         </div>
 
         {/* Footer */}
-        <div className="px-6 py-4 border-t border-gray-200 bg-gray-50 rounded-b-xl">
+        <div className="px-6 py-4 border-t border-[var(--brand-secondary)]/30 bg-[var(--brand-accent)]/10 rounded-b-xl">
           <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center justify-between">
-            <div className="text-sm text-gray-600">
-              <strong>Tip:</strong> Documents must have <code className="bg-gray-200 px-1 rounded">document:</code> as
-              the top-level key and sections with unique <code className="bg-gray-200 px-1 rounded">marker</code> fields.
+            <div className="text-sm text-[var(--brand-secondary)]">
+              <strong className="text-[var(--foreground)]">Tip:</strong> Documents must have <code className="bg-[var(--brand-secondary)]/20 px-1 rounded">document:</code> as
+              the top-level key and sections with unique <code className="bg-[var(--brand-secondary)]/20 px-1 rounded">marker</code> fields.
             </div>
             <button
               onClick={onClose}
-              className="px-4 py-2 bg-[var(--brand-primary)] text-white rounded-lg hover:opacity-90 transition-colors"
+              className="px-4 py-2 bg-[var(--brand-cta-bg)] text-[var(--brand-cta-text)] rounded-lg hover:opacity-90 transition-colors"
             >
               Got it
             </button>

--- a/ui/components/SplitDiffView.tsx
+++ b/ui/components/SplitDiffView.tsx
@@ -456,17 +456,20 @@ export default function SplitDiffView({ oldYaml, newYaml, diff }: SplitDiffViewP
         "&": {
           height: "100%",
           fontSize: "14px",
+          backgroundColor: "var(--brand-background)",
         },
         ".cm-content": {
           padding: "12px",
           fontFamily: "var(--font-mono), 'Fira Code', monospace",
+          backgroundColor: "var(--brand-background)",
         },
         ".cm-scroller": {
           overflow: "auto",
+          backgroundColor: "var(--brand-background)",
         },
         ".cm-gutters": {
-          backgroundColor: "#f6f8fa",
-          borderRight: "1px solid #e1e4e8",
+          backgroundColor: "var(--code-bg)",
+          borderRight: "1px solid var(--prose-border)",
         },
         ".cm-line": {
           position: "relative",
@@ -595,17 +598,20 @@ export default function SplitDiffView({ oldYaml, newYaml, diff }: SplitDiffViewP
         "&": {
           height: "100%",
           fontSize: "14px",
+          backgroundColor: "var(--brand-background)",
         },
         ".cm-content": {
           padding: "12px",
           fontFamily: "var(--font-mono), 'Fira Code', monospace",
+          backgroundColor: "var(--brand-background)",
         },
         ".cm-scroller": {
           overflow: "auto",
+          backgroundColor: "var(--brand-background)",
         },
         ".cm-gutters": {
-          backgroundColor: "#f6f8fa",
-          borderRight: "1px solid #e1e4e8",
+          backgroundColor: "var(--code-bg)",
+          borderRight: "1px solid var(--prose-border)",
         },
         ".cm-line": {
           position: "relative",

--- a/ui/components/SplitDiffView.tsx
+++ b/ui/components/SplitDiffView.tsx
@@ -731,36 +731,36 @@ export default function SplitDiffView({ oldYaml, newYaml, diff }: SplitDiffViewP
   return (
     <div className="w-full" data-testid="split-diff-view">
       {/* Header */}
-      <div className="border-b border-gray-200 bg-gray-50 flex">
-        <div className="flex-1 border-r border-gray-200 px-4 py-2">
-          <span className="text-sm font-medium text-gray-700">Old Version</span>
+      <div className="border-b border-[var(--brand-secondary)]/30 bg-[var(--brand-background)] flex">
+        <div className="flex-1 border-r border-[var(--brand-secondary)]/30 px-4 py-2">
+          <span className="text-sm font-medium text-[var(--foreground)]">Old Version</span>
         </div>
-        <div className="flex-1 border-r border-gray-200 px-4 py-2">
-          <span className="text-sm font-medium text-gray-700">New Version</span>
+        <div className="flex-1 border-r border-[var(--brand-secondary)]/30 px-4 py-2">
+          <span className="text-sm font-medium text-[var(--foreground)]">New Version</span>
         </div>
         <div className="w-80 px-4 py-2">
-          <span className="text-sm font-medium text-gray-700">Changes</span>
+          <span className="text-sm font-medium text-[var(--foreground)]">Changes</span>
         </div>
       </div>
 
       {/* Split view with discussions sidebar */}
-      <div className="border-b border-gray-200" style={{ minHeight: "400px", height: "600px" }}>
+      <div className="border-b border-[var(--brand-secondary)]/30" style={{ minHeight: "400px", height: "600px" }}>
         <div className="grid grid-cols-1 lg:grid-cols-[1fr_1fr_320px] h-full">
           {/* Old version editor */}
-          <div className="border-r border-gray-200 overflow-hidden bg-white">
+          <div className="border-r border-[var(--brand-secondary)]/30 overflow-hidden bg-[var(--brand-background)]">
             <div ref={oldEditorRef} className="h-full" />
           </div>
 
           {/* New version editor */}
-          <div className="border-r border-gray-200 overflow-hidden bg-white">
+          <div className="border-r border-[var(--brand-secondary)]/30 overflow-hidden bg-[var(--brand-background)]">
             <div ref={newEditorRef} className="h-full" />
           </div>
 
           {/* Changes sidebar */}
-          <div className="overflow-y-auto bg-gray-50 border-l border-gray-200">
+          <div className="overflow-y-auto bg-[var(--brand-background)] border-l border-[var(--brand-secondary)]/30">
             <div className="p-4 space-y-4">
               {changesWithPositions.length === 0 ? (
-                <p className="text-sm text-gray-500 italic">No changes found.</p>
+                <p className="text-sm text-[var(--brand-secondary)] italic">No changes found.</p>
               ) : (
                 changesWithPositions.map(({ change, oldLine, newLine }) => {
                   const lineNumber = newLine || oldLine;
@@ -778,7 +778,7 @@ export default function SplitDiffView({ oldYaml, newYaml, diff }: SplitDiffViewP
                           discussionRefs.current.delete(change.id);
                         }
                       }}
-                      className="bg-white border border-gray-300 rounded-lg shadow-sm cursor-pointer hover:shadow-md transition-shadow"
+                      className="bg-[var(--brand-background)] border border-[var(--brand-secondary)]/40 rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.08)] cursor-pointer hover:shadow-md transition-shadow"
                       onClick={() => {
                         // Scroll to line in editors using EditorView.scrollIntoView
                         // Add defensive checks to prevent CodeMirror errors
@@ -870,20 +870,20 @@ export default function SplitDiffView({ oldYaml, newYaml, diff }: SplitDiffViewP
                         });
                       }}
                     >
-                      <div className="w-full flex items-center justify-between p-3 border-b border-gray-200">
+                      <div className="w-full flex items-center justify-between p-3 border-b border-[var(--brand-secondary)]/30">
                         <div className="flex flex-col gap-2 flex-1 min-w-0">
                           <div className="flex items-center gap-2 flex-wrap">
                             {lineNumber ? (
                               <>
-                                <span className="text-xs font-semibold text-gray-700">
+                                <span className="text-xs font-semibold text-[var(--foreground)]">
                                   Line {lineNumber}
                                 </span>
-                                <span className="text-xs text-gray-500">
+                                <span className="text-xs text-[var(--brand-secondary)]">
                                   ({side === "new" ? "New" : "Old"} version)
                                 </span>
                               </>
                             ) : (
-                              <span className="text-xs font-semibold text-gray-700">
+                              <span className="text-xs font-semibold text-[var(--foreground)]">
                                 Change (no line mapping)
                               </span>
                             )}
@@ -904,7 +904,7 @@ export default function SplitDiffView({ oldYaml, newYaml, diff }: SplitDiffViewP
                                   ? 'bg-yellow-100 text-yellow-800 border-yellow-300'
                                   : change.change_type === ChangeType.TITLE_CHANGED
                                   ? 'bg-blue-100 text-blue-800 border-blue-300'
-                                  : 'bg-gray-100 text-gray-800 border-gray-300'
+                                  : 'bg-[var(--brand-secondary)]/20 text-[var(--foreground)] border-[var(--brand-secondary)]/40'
                               }`}>
                                 {change.change_type.split('_').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ')}
                               </span>
@@ -917,7 +917,7 @@ export default function SplitDiffView({ oldYaml, newYaml, diff }: SplitDiffViewP
                           </div>
                         </div>
                         <svg
-                          className={`w-4 h-4 text-gray-400 transition-transform flex-shrink-0 ${
+                          className={`w-4 h-4 text-[var(--brand-secondary)] transition-transform flex-shrink-0 ${
                             isExpanded ? "rotate-180" : ""
                           }`}
                           fill="none"
@@ -943,48 +943,48 @@ export default function SplitDiffView({ oldYaml, newYaml, diff }: SplitDiffViewP
                       )}
                       {isExpanded && !isDocumentDiffResult(change) && (
                         <div className="p-3 space-y-3">
-                          <div className="text-sm text-gray-700">
+                          <div className="text-sm text-[var(--foreground)]">
                             <div className="font-semibold mb-2">
                               {('change_type' in change ? change.change_type : 'unknown').split('_').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ')}
                             </div>
                             <div className="space-y-1.5 text-xs">
                               {('path' in change && change.path) && (
-                                <div className="text-gray-600">
+                                <div className="text-[var(--brand-secondary)]">
                                   <span className="font-semibold">Path:</span>{' '}
-                                  <span className="font-mono bg-gray-100 px-1 rounded">{change.path}</span>
+                                  <span className="font-mono bg-[var(--brand-secondary)]/15 px-1 rounded">{change.path}</span>
                                 </div>
                               )}
                               {('old_path' in change && change.old_path && change.old_path !== change.path) && (
-                                <div className="text-gray-600">
+                                <div className="text-[var(--brand-secondary)]">
                                   <span className="font-semibold">Old Path:</span>{' '}
-                                  <span className="font-mono bg-gray-100 px-1 rounded">{change.old_path}</span>
+                                  <span className="font-mono bg-[var(--brand-secondary)]/15 px-1 rounded">{change.old_path}</span>
                                 </div>
                               )}
                               {('new_path' in change && change.new_path && change.new_path !== change.path) && (
-                                <div className="text-gray-600">
+                                <div className="text-[var(--brand-secondary)]">
                                   <span className="font-semibold">New Path:</span>{' '}
-                                  <span className="font-mono bg-gray-100 px-1 rounded">{change.new_path}</span>
+                                  <span className="font-mono bg-[var(--brand-secondary)]/15 px-1 rounded">{change.new_path}</span>
                                 </div>
                               )}
                               {('old_key' in change && change.old_key) && (
-                                <div className="text-gray-600">
+                                <div className="text-[var(--brand-secondary)]">
                                   <span className="font-semibold">Old Key:</span>{' '}
-                                  <span className="font-mono bg-gray-100 px-1 rounded">{change.old_key}</span>
+                                  <span className="font-mono bg-[var(--brand-secondary)]/15 px-1 rounded">{change.old_key}</span>
                                 </div>
                               )}
                               {('new_key' in change && change.new_key) && (
-                                <div className="text-gray-600">
+                                <div className="text-[var(--brand-secondary)]">
                                   <span className="font-semibold">New Key:</span>{' '}
-                                  <span className="font-mono bg-gray-100 px-1 rounded">{change.new_key}</span>
+                                  <span className="font-mono bg-[var(--brand-secondary)]/15 px-1 rounded">{change.new_key}</span>
                                 </div>
                               )}
                             </div>
                           </div>
                           {/* Show old/new values if available */}
                           {('old_value' in change && change.old_value !== undefined) && (
-                            <div className="border-t border-gray-200 pt-2">
-                              <div className="text-xs font-semibold text-gray-600 mb-1">Old Value:</div>
-                              <div className="text-xs font-mono bg-red-50 border border-red-200 rounded p-2 text-gray-800 break-all">
+                            <div className="border-t border-[var(--brand-secondary)]/30 pt-2">
+                              <div className="text-xs font-semibold text-[var(--brand-secondary)] mb-1">Old Value:</div>
+                              <div className="text-xs font-mono bg-red-50 border border-red-200 rounded p-2 text-[var(--foreground)] break-all">
                                 {typeof change.old_value === 'object'
                                   ? JSON.stringify(change.old_value, null, 2)
                                   : String(change.old_value)}
@@ -992,9 +992,9 @@ export default function SplitDiffView({ oldYaml, newYaml, diff }: SplitDiffViewP
                             </div>
                           )}
                           {('new_value' in change && change.new_value !== undefined) && (
-                            <div className="border-t border-gray-200 pt-2">
-                              <div className="text-xs font-semibold text-gray-600 mb-1">New Value:</div>
-                              <div className="text-xs font-mono bg-green-50 border border-green-200 rounded p-2 text-gray-800 break-all">
+                            <div className="border-t border-[var(--brand-secondary)]/30 pt-2">
+                              <div className="text-xs font-semibold text-[var(--brand-secondary)] mb-1">New Value:</div>
+                              <div className="text-xs font-mono bg-green-50 border border-green-200 rounded p-2 text-[var(--foreground)] break-all">
                                 {typeof change.new_value === 'object'
                                   ? JSON.stringify(change.new_value, null, 2)
                                   : String(change.new_value)}

--- a/ui/components/Tooltip.tsx
+++ b/ui/components/Tooltip.tsx
@@ -20,11 +20,11 @@ export default function Tooltip({
       <TooltipPrimitive.Portal>
         <TooltipPrimitive.Content
           side={side}
-          className="bg-gray-900 text-white text-sm px-3 py-2 rounded-lg shadow-lg z-50 max-w-xs"
+          className="bg-[var(--foreground)] text-[var(--brand-background)] text-sm px-3 py-2 rounded-lg shadow-[0_4px_12px_rgba(0,0,0,0.08)] z-50 max-w-xs"
           sideOffset={5}
         >
           {content}
-          <TooltipPrimitive.Arrow className="fill-gray-900" />
+          <TooltipPrimitive.Arrow className="fill-[var(--foreground)]" />
         </TooltipPrimitive.Content>
       </TooltipPrimitive.Portal>
     </TooltipPrimitive.Root>

--- a/ui/components/YamlEditor.tsx
+++ b/ui/components/YamlEditor.tsx
@@ -68,18 +68,21 @@ export default function YamlEditor({
         "&": {
           height: "100%",
           fontSize: "14px",
+          backgroundColor: "var(--brand-background)",
         },
         ".cm-content": {
           padding: "12px",
           minHeight: "400px",
           fontFamily: "var(--font-mono), 'Fira Code', monospace",
+          backgroundColor: "var(--brand-background)",
         },
         ".cm-scroller": {
           overflow: "auto",
+          backgroundColor: "var(--brand-background)",
         },
         ".cm-gutters": {
-          backgroundColor: "#f6f8fa",
-          borderRight: "1px solid #e1e4e8",
+          backgroundColor: "var(--code-bg)",
+          borderRight: "1px solid var(--prose-border)",
         },
         ".cm-lineNumbers .cm-gutterElement": {
           padding: "0 8px",
@@ -124,7 +127,7 @@ export default function YamlEditor({
   }, [value]);
 
   return (
-    <div className={`border border-gray-300 rounded-lg overflow-hidden ${className}`}>
+    <div className={`border border-[var(--brand-secondary)]/30 rounded-lg overflow-hidden bg-[var(--brand-background)] ${className}`}>
       <div ref={editorRef} className="h-full" />
     </div>
   );

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -24,9 +24,9 @@
         "diff-match-patch": "^1.0.5",
         "js-yaml": "^4.1.1",
         "mermaid": "^10.9.1",
-        "next": "16.0.5",
-        "react": "19.2.0",
-        "react-dom": "19.2.0",
+        "next": "16.0.7",
+        "react": "19.2.1",
+        "react-dom": "19.2.1",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
         "zustand": "^5.0.8"
@@ -39,7 +39,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
-        "eslint-config-next": "16.0.5",
+        "eslint-config-next": "16.0.7",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -1372,15 +1372,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.0.5",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.0.5.tgz",
-      "integrity": "sha512-jRLOw822AE6aaIm9oh0NrauZEM0Vtx5xhYPgqx89txUmv/UmcRwpcXmGeQOvYNT/1bakUwA+nG5CA74upYVVDw==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.0.7.tgz",
+      "integrity": "sha512-gpaNgUh5nftFKRkRQGnVi5dpcYSKGcZZkQffZ172OrG/XkrnS7UBTQ648YY+8ME92cC4IojpI2LqTC8sTDhAaw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.0.5",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.0.5.tgz",
-      "integrity": "sha512-m1zPz6hsBvQt1CMRz7rTga8OXpRE9rVW4JHCSjW+tswTxiEU+6ev+GTlgm7ZzcCiMEVQAHTNhpEGFzDtVha9qg==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.0.7.tgz",
+      "integrity": "sha512-hFrTNZcMEG+k7qxVxZJq3F32Kms130FAhG8lvw2zkKBgAcNOJIxlljNiCjGygvBshvaGBdf88q2CqWtnqezDHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1388,9 +1388,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.0.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.0.5.tgz",
-      "integrity": "sha512-65Mfo1rD+mVbJuBTlXbNelNOJ5ef+5pskifpFHsUt3cnOWjDNKctHBwwSz9tJlPp7qADZtiN/sdcG7mnc0El8Q==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.0.7.tgz",
+      "integrity": "sha512-LlDtCYOEj/rfSnEn/Idi+j1QKHxY9BJFmxx7108A6D8K0SB+bNgfYQATPk/4LqOl4C0Wo3LACg2ie6s7xqMpJg==",
       "cpu": [
         "arm64"
       ],
@@ -1404,9 +1404,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.0.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.0.5.tgz",
-      "integrity": "sha512-2fDzXD/JpEjY500VUF0uuGq3YZcpC6XxmGabePPLyHCKbw/YXRugv3MRHH7MxE2hVHtryXeSYYnxcESb/3OUIQ==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.0.7.tgz",
+      "integrity": "sha512-rtZ7BhnVvO1ICf3QzfW9H3aPz7GhBrnSIMZyr4Qy6boXF0b5E3QLs+cvJmg3PsTCG2M1PBoC+DANUi4wCOKXpA==",
       "cpu": [
         "x64"
       ],
@@ -1420,9 +1420,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.0.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.0.5.tgz",
-      "integrity": "sha512-meSLB52fw4tgDpPnyuhwA280EWLwwIntrxLYjzKU3e3730ur2WJAmmqoZ1LPIZ2l3eDfh9SBHnJGTczbgPeNeA==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.0.7.tgz",
+      "integrity": "sha512-mloD5WcPIeIeeZqAIP5c2kdaTa6StwP4/2EGy1mUw8HiexSHGK/jcM7lFuS3u3i2zn+xH9+wXJs6njO7VrAqww==",
       "cpu": [
         "arm64"
       ],
@@ -1436,9 +1436,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.0.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.0.5.tgz",
-      "integrity": "sha512-aAJtQkvUzz5t0xVAmK931SIhWnSQAaEoTyG/sKPCYq2u835K/E4a14A+WRPd4dkhxIHNudE8dI+FpHekgdrA4g==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.0.7.tgz",
+      "integrity": "sha512-+ksWNrZrthisXuo9gd1XnjHRowCbMtl/YgMpbRvFeDEqEBd523YHPWpBuDjomod88U8Xliw5DHhekBC3EOOd9g==",
       "cpu": [
         "arm64"
       ],
@@ -1452,9 +1452,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.0.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.0.5.tgz",
-      "integrity": "sha512-bYwbjBwooMWRhy6vRxenaYdguTM2hlxFt1QBnUF235zTnU2DhGpETm5WU93UvtAy0uhC5Kgqsl8RyNXlprFJ6Q==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.0.7.tgz",
+      "integrity": "sha512-4WtJU5cRDxpEE44Ana2Xro1284hnyVpBb62lIpU5k85D8xXxatT+rXxBgPkc7C1XwkZMWpK5rXLXTh9PFipWsA==",
       "cpu": [
         "x64"
       ],
@@ -1468,9 +1468,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.0.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.0.5.tgz",
-      "integrity": "sha512-iGv2K/4gW3mkzh+VcZTf2gEGX5o9xdb5oPqHjgZvHdVzCw0iSAJ7n9vKzl3SIEIIHZmqRsgNasgoLd0cxaD+tg==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.0.7.tgz",
+      "integrity": "sha512-HYlhqIP6kBPXalW2dbMTSuB4+8fe+j9juyxwfMwCe9kQPPeiyFn7NMjNfoFOfJ2eXkeQsoUGXg+O2SE3m4Qg2w==",
       "cpu": [
         "x64"
       ],
@@ -1484,9 +1484,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.0.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.0.5.tgz",
-      "integrity": "sha512-6xf52Hp4SH9+4jbYmfUleqkuxvdB9JJRwwFlVG38UDuEGPqpIA+0KiJEU9lxvb0RGNo2i2ZUhc5LHajij9H9+A==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.0.7.tgz",
+      "integrity": "sha512-EviG+43iOoBRZg9deGauXExjRphhuYmIOJ12b9sAPy0eQ6iwcPxfED2asb/s2/yiLYOdm37kPaiZu8uXSYPs0Q==",
       "cpu": [
         "arm64"
       ],
@@ -1500,9 +1500,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.0.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.0.5.tgz",
-      "integrity": "sha512-06kTaOh+Qy/kguN+MMK+/VtKmRkQJrPlGQMvCUbABk1UxI5SKTgJhbmMj9Hf0qWwrS6g9JM6/Zk+etqeMyvHAw==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.0.7.tgz",
+      "integrity": "sha512-gniPjy55zp5Eg0896qSrf3yB1dw4F/3s8VK1ephdsZZ129j2n6e1WqCbE2YgcKhW9hPB9TVZENugquWJD5x0ug==",
       "cpu": [
         "x64"
       ],
@@ -4633,13 +4633,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.0.5",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.0.5.tgz",
-      "integrity": "sha512-9rBjZ/biSpolkIUiqvx/iwJJaz8sxJ6pKWSPptJenpj01HlWbCDeaA1v0yG3a71IIPMplxVCSXhmtP27SXqMdg==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.0.7.tgz",
+      "integrity": "sha512-WubFGLFHfk2KivkdRGfx6cGSFhaQqhERRfyO8BRx+qiGPGp7WLKcPvYC4mdx1z3VhVRcrfFzczjjTrbJZOpnEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.0.5",
+        "@next/eslint-plugin-next": "16.0.7",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",
@@ -8130,12 +8130,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.0.5",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.0.5.tgz",
-      "integrity": "sha512-XUPsFqSqu/NDdPfn/cju9yfIedkDI7ytDoALD9todaSMxk1Z5e3WcbUjfI9xsanFTys7xz62lnRWNFqJordzkQ==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.0.7.tgz",
+      "integrity": "sha512-3mBRJyPxT4LOxAJI6IsXeFtKfiJUbjCLgvXO02fV8Wy/lIhPvP94Fe7dGhUgHXcQy4sSuYwQNcOLhIfOm0rL0A==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.0.5",
+        "@next/env": "16.0.7",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -8148,14 +8148,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.0.5",
-        "@next/swc-darwin-x64": "16.0.5",
-        "@next/swc-linux-arm64-gnu": "16.0.5",
-        "@next/swc-linux-arm64-musl": "16.0.5",
-        "@next/swc-linux-x64-gnu": "16.0.5",
-        "@next/swc-linux-x64-musl": "16.0.5",
-        "@next/swc-win32-arm64-msvc": "16.0.5",
-        "@next/swc-win32-x64-msvc": "16.0.5",
+        "@next/swc-darwin-arm64": "16.0.7",
+        "@next/swc-darwin-x64": "16.0.7",
+        "@next/swc-linux-arm64-gnu": "16.0.7",
+        "@next/swc-linux-arm64-musl": "16.0.7",
+        "@next/swc-linux-x64-gnu": "16.0.7",
+        "@next/swc-linux-x64-musl": "16.0.7",
+        "@next/swc-win32-arm64-msvc": "16.0.7",
+        "@next/swc-win32-x64-msvc": "16.0.7",
         "sharp": "^0.34.4"
       },
       "peerDependencies": {
@@ -8632,24 +8632,24 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
-      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
+      "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
-      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "version": "19.2.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
+      "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.0"
+        "react": "^19.2.1"
       }
     },
     "node_modules/react-is": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -27,9 +27,9 @@
     "codemirror": "^6.0.2",
     "diff-match-patch": "^1.0.5",
     "js-yaml": "^4.1.1",
-    "next": "16.0.5",
-    "react": "19.2.0",
-    "react-dom": "19.2.0",
+    "next": "16.0.7",
+    "react": "19.2.1",
+    "react-dom": "19.2.1",
     "mermaid": "^10.9.1",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
@@ -43,7 +43,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "16.0.5",
+    "eslint-config-next": "16.0.7",
     "tailwindcss": "^4",
     "typescript": "^5"
   }


### PR DESCRIPTION
Applies The Pitz Studio branding (colors, typography, CTAs, cards) across the yamly Next.js UI per brand guidelines.

## Summary
- **Global foundation:** Pitz palette in `globals.css` (beige `#E8DCC4`, accent `#9DC9B8`, black CTAs), Instrument Serif + Work Sans in `layout.tsx`
- **Main page:** Beige background, white header/cards with Pitz shadow, Run diff CTA black with arrow, tabs and spacing per brand
- **Components:** Pitz vars for text/backgrounds/borders, white cards with shadow `0 4px 12px rgba(0,0,0,0.08)`, black primary buttons, accent for links and focus, arrows on CTAs where appropriate. Diff semantic colors (add/remove/modify/move) preserved for clarity.

## Verification
- `pytest`, `ruff check`, `mypy` pass
- `npm run build` (Next.js) passes

Made with [Cursor](https://cursor.com)